### PR TITLE
feat: add magpie as transformation pipeline

### DIFF
--- a/data/public/magpie/data.jsonl
+++ b/data/public/magpie/data.jsonl
@@ -1,0 +1,12 @@
+{"task_name": "magpie", "is_seed": false, "question": "What is the world's largest desert?", "answer": "The Sahara Desert"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the largest island in the Mediterranean Sea?", "answer": "Sicily"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the longest mountain range in South America?", "answer": "The Andes"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the longest mountain range in the world?", "answer": "The Andes mountain range"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the longest mountain range in South America?", "answer": "The Andes mountain range"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the largest city in Scandinavia?", "answer": "Stockholm"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the longest river in South America?", "answer": "Amazon River"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the strait that separates the continents of Asia and Africa?", "answer": "Bab-el-Mandeb"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the mountain range that runs along the border between France and Spain?", "answer": "The Pyrenees mountain range runs along the border between France and Spain, it is a popular destination for hiking and skiing."}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the strait that separates the continents of Asia and Africa?", "answer": "Bab-el-Mandeb"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the longest river in South America?", "answer": "Amazon River"}
+{"task_name": "magpie", "is_seed": false, "question": "What is the name of the largest island in the Mediterranean Sea?", "answer": "Sicily is the largest island in the Mediterranean Sea, it is an autonomous region of Italy and has a rich history and culture."}

--- a/fms_dgt/public/databuilders/magpie/README.md
+++ b/fms_dgt/public/databuilders/magpie/README.md
@@ -14,7 +14,8 @@ pip install -e ".[all]"
 
 ### Required in task.yaml [here](../../../../tasks/public/magpie/task.yaml)
 
-- `seed_datastore`:
+- data:
+  - `type`: default
   - `data_path`: input data file path in .jsonl format
 
 ## Databuilder specifications

--- a/fms_dgt/public/databuilders/magpie/README.md
+++ b/fms_dgt/public/databuilders/magpie/README.md
@@ -1,0 +1,176 @@
+# Magpie Transformation
+
+Data builder used to transform existing datasets with Magpie tags, deduplication and/or filtering.
+
+## Setup
+
+Please ensure you have installed the DGT repo by doing
+
+```bash
+pip install -e ".[all]"
+```
+
+## Task specifications
+
+### Required in task.yaml [here](../../../../tasks/public/magpie/task.yaml)
+
+- `seed_datastore`:
+  - `data_path`: input data file path in .jsonl format
+
+## Databuilder specifications
+
+### Required in data builder config [here](./magpie.yaml).
+
+By default the magpie.yaml config has all three steps of Magpie ie Tagging, Deduplication and Filtering based on the previous steps enabled. The three corresponding blocks are namely tagger, dedup and filter respectively. You can choose to keep any one of them or all of them.
+
+The most important part that needs to be changed in each of the block that is going to be used in this config, is the `input_map`
+
+> **_NOTE:_** Do not use reserved keywords as field names 'magpie_input', 'magpie_output', 'magpie_mt_input' or 'magpie_tags' in your data file.
+> These are used within Magpie and will be overriden.
+
+**Use of the `input_map` is show in each scenario below:**
+
+#### Tagger
+
+##### Single Input and Output
+
+- `name`: tagger
+- `input_map` :
+  - `question`: magpie_input
+  - `answer`: magpie_output
+
+shows that in the taggging step, the code is expecting to find `question` and `answer` in the data (`seed_datastore`) and will treat them as input and its corresponding output respectively in order to assess their quality.
+
+##### Multi Turn Conversations
+
+In the case of multi-turn conversations, the conversations should follow OpenAI chat format, for example
+
+```
+messages : {'role': 'user', 'content': 'What is 1+1', 'role': 'asistant', 'content': '1+1 is 2'}
+```
+
+The input_map should look like this:
+
+- `name`: tagger
+- `input_map` :
+  - `messages`: magpie_mt_input
+
+> **_NOTE:_** In the case of multi-turn only messages with the field 'content'/'text'/'value' are supported by Magpie. Others will be skipped
+> **_NOTE:_** In the case of multi-turn only 'user' and 'assistant' messages are supported by Magpie. Others will be skipped
+
+`lm_config` under tagger can be changed to change the source of model of llm (eg. ollama) and batch_size for processing.
+
+`tasks : ["quality", "sample_quality", "difficulty"] ` are the default tagging prompts . Any of these can be removed by overriding `tasks:[]` under the magpie tagger block .
+
+"classification" is an optional task as well.
+
+#### Dedup
+
+Similarly `input_map` in the `dedup` block needs the name of the field for the input, the field containing a unique id (optional) and the field containing the tags from the tagger step (optional).
+If either of the optional fields are not present then it will create the fields 'id' and 'magpie_tags'.
+
+- `name`: dedup
+- `input_map` :
+  - `question`: magpie_input
+  - `sample_id`: id (optional)
+  - `magpie_tags`: magpie_tags (optional)
+
+#### Filter
+
+For the filter block, it needs the names of field for input, output, tags and unique id.
+
+- `name`: filter
+- `input_map` :
+  - `question`: magpie_input
+  - `answer`: magpie_output
+  - `magpie_tags`: field
+  - `sample_id`: id
+
+If `id` does not exist in the data and was created in the dedup step, make sure to update the input map for filter as follows:
+
+- `input_map` :
+  - `question`: magpie_input
+  - `answer`: magpie_output
+  - `magpie_tags`: field
+  - `id`: id
+
+`filter_criteria:` can be used to change the filter criteria
+`remove_duplicate` True/False (default=True)
+
+## How to run
+
+To execute this databuilder, run the following command
+
+```bash
+python -m fms_dgt.public --task-path ./tasks/public/magpie/task.yaml --output-dir output/magpie_output
+```
+
+> [!WARNING]  
+> **Issue**
+>
+> Segmentation faults and similar errors on macOS
+>
+> **Solution**
+>
+> Set the following environment parameters
+>
+> 1. Disable OpenMP threading via `export OMP_NUM_THREADS=1`
+> 2. If error still persists, disable PyTorch MPS device via `export PYTORCH_MPS_DISABLE=1`
+> 3. If error still persists, disable llama.cpp metal via `export LLAMA_NO_METAL=1`
+> 4. Final attempt can be made as a dangerous workaround via `export KMP_DUPLICATE_LIB_OK=TRUE`
+>
+> Reference: https://github.com/neuml/txtai/issues/813#issuecomment-2485349327
+
+## Output
+
+Under the output folder, final_data.jsonl will contain the data file in the same format as input data file , tagged, deduped and filtered if enabled.
+
+The file filter.jsonl under the blocks folder inside output will contain the data samples that were filtered along with their tags and dedup info.
+
+## Filtering
+
+### Tagging
+
+Tagging the input and output (in case of single turn) or the conversation (in case of multi turn) in terms of :
+
+```
+quality (question) : [
+"very poor",
+"poor",
+"average",
+"good",
+"excellent",
+]
+
+sample_quality score(question and response) : ["1", "2", "3", "4", "5"]
+
+difficulty : [
+"very easy",
+"easy",
+"medium",
+"hard",
+"very hard",
+]
+
+classification of task: []
+
+knowledge : []
+```
+
+### Deduplication
+
+It calculates the most similar sample based on distance using sentence transformer and outputs the id of the most similar to the sample.
+
+### Filtering
+
+Filters the magpie tagged data based on certain criteria. These are mentioned in `filter_criteria` under the filter block.
+
+```
+`input_quality` in ["good", "excellent"]
+`judge_quality_score` in ["4","5"]
+`min_similar_uuid` is None or `min_similar_uuid`=`id`
+```
+
+## Notice
+
+Modified version of [**Magpie**](https://magpie-align.github.io/) enabled to use opensource models.

--- a/fms_dgt/public/databuilders/magpie/generate.py
+++ b/fms_dgt/public/databuilders/magpie/generate.py
@@ -1,0 +1,127 @@
+# Standard
+from typing import Iterable, Optional
+
+# Local
+from fms_dgt.base.databuilder import TransformationDataBuilder
+from fms_dgt.base.registry import register_data_builder
+from fms_dgt.public.blocks.magpie.distance import MagpieDistance
+from fms_dgt.public.blocks.magpie.filter import MagpieFilter
+from fms_dgt.public.blocks.magpie.tag import MagpieTagger
+from fms_dgt.public.databuilders.magpie.task import (
+    MagpieTransformData,
+    MagpieTransformTask,
+)
+from fms_dgt.utils import dgt_logger
+
+# ===========================================================================
+#                       CONSTANTS
+# ===========================================================================
+_MP_INPUT_DATA = "MP_INP_DATA"
+
+# ===========================================================================
+#                       MAIN CLASS
+# ===========================================================================
+
+
+@register_data_builder("magpie")
+class MagpieTransformDataBuilder(TransformationDataBuilder):
+    """Class for Magpie Transformation"""
+
+    TASK_TYPE: MagpieTransformTask = MagpieTransformTask
+
+    # tagger is the Magpie based tagger to rate synthetic examples
+    tagger: Optional[MagpieTagger]
+    dedup: Optional[MagpieDistance]
+    filter: Optional[MagpieFilter]
+
+    def __call__(
+        self,
+        data_points: MagpieTransformData,
+    ) -> Iterable[dict]:
+        # Step 1: Initialize outputs from inputs
+        outputs = [{**data_point.input, _MP_INPUT_DATA: data_point} for data_point in data_points]
+
+        # Step 2: Invoke magpie tagger, if requested
+        if hasattr(self, "tagger"):
+            dgt_logger.info(
+                'Tagging %d data points with "%s"...',
+                len(outputs),
+                ".".join([self.tagger.__module__, self.tagger.__class__.__name__]),
+            )
+
+            # Step 2.a: Tag
+            tagged_outputs = self.tagger(outputs)
+
+            # Step 2.b: Re-build outputs using tagger outputs
+            outputs = [
+                {
+                    **tagged_output[_MP_INPUT_DATA].input,
+                    "magpie_tags": tagged_output["magpie_tags"],
+                    _MP_INPUT_DATA: tagged_output[_MP_INPUT_DATA],
+                }
+                for tagged_output in tagged_outputs
+            ]
+
+        # Step 3: Invoke magpie deduplicator, if requested
+        if hasattr(self, "dedup"):
+            dgt_logger.info(
+                'Deduping %d data points with "%s"...',
+                len(outputs),
+                ".".join([self.dedup.__module__, self.dedup.__class__.__name__]),
+            )
+
+            # Step 3.a: Deduplicate
+            dedup_outputs = self.dedup(outputs)
+
+            # Step 3.b: Re-build outputs using dedup outputs
+            outputs = [
+                {
+                    **dedup_output[_MP_INPUT_DATA].input,
+                    "magpie_tags": dedup_output["magpie_tags"],
+                    "id": dedup_output["id"],
+                    _MP_INPUT_DATA: dedup_output[_MP_INPUT_DATA],
+                }
+                for dedup_output in dedup_outputs
+            ]
+
+        # Step 4: Invoke magpie filteration, if requested
+        if hasattr(self, "filter"):
+            dgt_logger.info(
+                'Filtering %d data points with "%s"...',
+                len(outputs),
+                ".".join([self.filter.__module__, self.filter.__class__.__name__]),
+            )
+
+            # Step 4.a: Filter
+            filtered_outputs = self.filter(
+                [
+                    {
+                        **output,
+                        "store_names": self.get_block_store_names(
+                            block_name=self.filter.name, task_name=output["task_name"]
+                        ),
+                    }
+                    for output in outputs
+                ]
+            )
+
+            # Build outputs using filtered outputs
+            outputs = [
+                {
+                    **filtered_output[_MP_INPUT_DATA].input,
+                    "magpie_tags": filtered_output["magpie_tags"],
+                    _MP_INPUT_DATA: filtered_output[_MP_INPUT_DATA],
+                }
+                for filtered_output in filtered_outputs
+            ]
+
+        # Step 5: Return
+        return [
+            MagpieTransformData(
+                task_name=output[_MP_INPUT_DATA].task_name,
+                is_seed=False,
+                input=output[_MP_INPUT_DATA].input,
+                magpie_tags=output["magpie_tags"],
+            )
+            for output in outputs
+        ]

--- a/fms_dgt/public/databuilders/magpie/magpie.yaml
+++ b/fms_dgt/public/databuilders/magpie/magpie.yaml
@@ -1,0 +1,38 @@
+name: magpie
+blocks:
+  - name: tagger
+    type: magpie_tag
+    input_map:
+      question: magpie_input
+      answer: magpie_output
+      messages: magpie_mt_input
+    lm_config:
+      type: ollama
+      model_id_or_path: mistral-small3.2
+      temperature: 0.0
+      max_new_tokens: 512
+      stop: ["Q:"]
+    tag_task: all
+  - name: dedup
+    type: magpie_distance
+    input_map:
+      question: magpie_input
+      messages: magpie_mt_input
+      magpie_tags: magpie_tags
+      id: id
+  - name: filter
+    type: magpie_filter
+    # Filter out invalid data points
+    filter: true
+    # Magpie filter attributes
+    filter_type: all
+    filter_criteria:
+      input_quality: ["good", "excellent"]
+      sample_quality: ["4", "5"]
+    remove_duplicates: True
+    input_map:
+      question: magpie_input
+      answer: magpie_output
+      messages: magpie_mt_input
+      magpie_tags: field
+      id: id

--- a/fms_dgt/public/databuilders/magpie/task.py
+++ b/fms_dgt/public/databuilders/magpie/task.py
@@ -1,0 +1,49 @@
+# Standard
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+# Local
+from fms_dgt.base.task import DataPoint, TransformationTask
+
+
+@dataclass(kw_only=True)
+class MagpieTransformData(DataPoint):
+    input: List[Dict[str, Any]]
+    magpie_tags: Optional[List[Dict[str, Any]]] = None
+
+
+class MagpieTransformTask(TransformationTask):
+
+    INPUT_DATA_TYPE = MagpieTransformData
+    OUTPUT_DATA_TYPE = MagpieTransformData
+
+    def instantiate_input_example(self, **kwargs: Any):
+        return self.INPUT_DATA_TYPE(task_name=self.name, input=kwargs)
+
+    def get_batch_examples(self) -> List[DataPoint]:
+        """Returns batch of examples from dataloader.
+
+        Returns:
+            List[DataPoint]: List of examples to be used by SDG process.
+        """
+        examples = []
+
+        # Load examples from seed data loader sequentially
+        while True:
+            example = self.get_example()
+            if example is None:
+                break
+            examples.append(example)
+
+        # Return
+        return examples
+
+    def save_final_data(self):
+        loaded_data = self.datastore.load_data() or []
+        if loaded_data:
+            self.final_datastore.save_data(
+                [
+                    {**data_point["input"], "magpie_tags": data_point["magpie_tags"]}
+                    for data_point in loaded_data
+                ]
+            )

--- a/tasks/public/magpie/task.yaml
+++ b/tasks/public/magpie/task.yaml
@@ -1,0 +1,15 @@
+######################################################
+#                   MANDATORY FIELDS
+######################################################
+task_name: magpie
+task_description: Magpie transformation pipeline consisting of tagging, dedup and/or filtering
+created_by: IBM Research
+
+data_builder: magpie
+
+######################################################
+#                   RESERVED FIELDS
+######################################################
+data:
+  type: default
+  data_path: ${DGT_DATA_DIR}/public/magpie/data.jsonl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->
This PR adds Magpie Tagging, Deduplication and Filtering as a transformation pipeline using existing Magpie blocks. This is useful to tag, deduplicate and filter pre-existing data or data that has already been generated.

Tags are generated for metrics such as input quality, sample quality (input and output), difficulty, classification using an LLM.
Sentence Transformer is used to find distance between the inputs.
Filtering is based on user provided criteria for the tags.

This is a modified version of [**Magpie Filtering**](https://magpie-align.github.io/) enabled to use open-source models.

Command to run:

```bash
python -m fms_dgt.public --task-path ./tasks/public/magpie/task.yaml --output-dir output/magpie_output
```
## Related Issue
Supports #ISSUE_NUMBER

## Related PRs
This PR is not dependent on any other PR

## What this PR does / why we need it

## Special notes for your reviewer

## If applicable**
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
