### PR TITLE
fix (exception): Fix exception type in generate_data

### DIFF
--- a/fms_dgt/generate_data.py
+++ b/fms_dgt/generate_data.py
@@ -119,7 +119,7 @@ def generate_data(
                 }
                 task_inits.append(task_init)
         else:
-            raise FileExistsError(f"Error: task path ({task_path}) does not exist.")
+            raise FileNotFoundError(f"Error: task path ({task_path}) does not exist.")
 
     # capture tasks specified only in config overrides
     for task_name, task_override in task_overrides.items():


### PR DESCRIPTION
## What this PR does / why we need it
We raise an incorrect exception when a task file doesn't exist

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
