### PR TITLE
feat (async-pipeline): concurrent LLM execution, acall/aexecute, and retry hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,75 @@
-# an environment variable available to anyone using DGT
+# ===========================================================================
+# DGT Environment Configuration
+# Copy this file to .env and fill in values for your environment.
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Core paths
+# ---------------------------------------------------------------------------
+# Directory where input data files are read from.
 DGT_DATA_DIR="data"
+
+# Directory where generated outputs are written.
 DGT_OUTPUT_DIR="output"
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+# Directory where telemetry files (traces.jsonl, events.jsonl) are written.
+# Files rotate at 100 MB; rotated files older than 14 days are deleted.
 DGT_TELEMETRY_DIR="telemetry"
 
+# Set to 1 to disable all telemetry (no files written, zero overhead).
+DGT_TELEMETRY_DISABLE=0
+
+# Payload recording — OFF by default.
+# When enabled, LLM prompts and completions are written into traces.jsonl.
+# WARNING: Use only for debugging small targeted runs. On large runs this will
+# fill your telemetry directory quickly and trigger frequent file rotation.
+# Turn off again after debugging.
+DGT_TELEMETRY_RECORD_PAYLOADS=0
+
+# Maximum characters to record per prompt / per chat message content /
+# per completion when payload recording is on. Content beyond this limit is
+# truncated and the span attribute "payload_truncated" is set to true.
+# Default: 4096. Raise only if you need full context for very long prompts.
+DGT_TELEMETRY_PAYLOAD_MAX_CHARS=4096
+
+# ---------------------------------------------------------------------------
 # WatsonX AI [Optional]
+# Required when using the "watsonx" LLM block type.
+# ---------------------------------------------------------------------------
 WATSONX_API_KEY=""
 WATSONX_PROJECT_ID=""
 
+# ---------------------------------------------------------------------------
 # OpenAI [Optional]
+# Required when using the "openai" or "vllm-remote" LLM block types.
+# ---------------------------------------------------------------------------
 OPENAI_API_KEY=""
 
+# ---------------------------------------------------------------------------
 # Azure OpenAI [Optional]
+# Required when using the "azure-openai" LLM block type.
+# ---------------------------------------------------------------------------
 AZURE_OPENAI_API_KEY=""
 
-# Antropic [Optional]
+# ---------------------------------------------------------------------------
+# Anthropic [Optional]
+# Required when using the "anthropic" LLM block type.
+# ---------------------------------------------------------------------------
 ANTHROPIC_API_KEY=""
 
-# common error with vllm, disable if you want this check to happen
+# ---------------------------------------------------------------------------
+# vLLM
+# ---------------------------------------------------------------------------
+# Skips the peer-to-peer GPU check at startup. Set to 1 if you see P2P errors
+# on multi-GPU machines where P2P is not supported.
 VLLM_SKIP_P2P_CHECK=1
 
-# know error with FAISS on MacOS (used in magpie's distance block)
+# ---------------------------------------------------------------------------
+# System / third-party workarounds
+# ---------------------------------------------------------------------------
+# Limits OpenMP thread count. Required on macOS to avoid a known crash in
+# FAISS (used by the Magpie distance block).
 OMP_NUM_THREADS=1

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To test whether you have been successful, run the following operation that refer
 > ```
 
 ```bash
-python -m fms_dgt.core --task-paths ./tasks/core/simple/logical_reasoning/causal --restart-generation
+python -m fms_dgt.core --task-paths ./tasks/core/simple/logical_reasoning/causal --restart
 ```
 
 - Using [IBM watsonx](https://www.ibm.com/products/watsonx)
@@ -80,7 +80,7 @@ python -m fms_dgt.core --task-paths ./tasks/core/simple/logical_reasoning/causal
 > you must set up a `WATSONX_API_KEY` and `WATSONX_PROJECT_ID` before using watsonx API service
 
 ```bash
-python -m fms_dgt.core --task-paths ./tasks/core/simple/logical_reasoning/causal --restart-generation --config-path configs/core/watsonx_simple.yaml
+python -m fms_dgt.core --task-paths ./tasks/core/simple/logical_reasoning/causal --restart --config-path configs/core/watsonx_simple.yaml
 ```
 
 If successful, you should see the outputs of the command in the `./output` directory

--- a/fms_dgt/__main__.py
+++ b/fms_dgt/__main__.py
@@ -113,7 +113,9 @@ def add_task_args(parser: argparse.ArgumentParser):
         help="Number of machine generated examples to pass from data loader to data builder.",
     )
     group.add_argument(
+        "--restart",
         "--restart-generation",
+        dest="restart_generation",
         action="store_true",
         help="Entirely restart instruction generation.",
     )

--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -5,6 +5,7 @@
 from abc import abstractmethod
 from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, Iterable, List, Tuple
+import asyncio
 import dataclasses
 import inspect
 import logging
@@ -38,19 +39,48 @@ _SRC_DATA = "SRC_DATA"
 # ===========================================================================
 #                       HELPER FUNCTIONS
 # ===========================================================================
-def get_row_name(gen_inst: DATASET_ROW_TYPE) -> str:
+_warned_missing_task_name: set = set()
+
+
+def get_row_name(gen_inst: DATASET_ROW_TYPE) -> str | None:
     """Gets the task name associated with the particular input instance.
+
+    Lookup order:
+    1. ``task_name`` directly on the object (covers ``DataPoint`` and dicts).
+    2. ``SRC_DATA`` recursion (covers ``BlockData`` / ``ValidatorBlockData``
+       whose original row is a ``DataPoint`` carrying ``task_name``).
+    3. Returns ``None`` and emits a one-time warning per type so developers
+       know that structured logs and lifecycle events will be degraded.
 
     Args:
         gen_inst (DATASET_ROW_TYPE): The input to get the task name from.
 
     Returns:
-        str: Name of task
+        str | None: Name of task, or None if not found.
     """
     if isinstance(gen_inst, dict):
-        return gen_inst.get("task_name")
+        if "task_name" in gen_inst:
+            return gen_inst["task_name"]
+        src = gen_inst.get("SRC_DATA")
+        if src is not None:
+            return get_row_name(src)
     else:
-        return getattr(gen_inst, "task_name")
+        task_name = getattr(gen_inst, "task_name", None)
+        if task_name is not None:
+            return task_name
+        src = getattr(gen_inst, "SRC_DATA", None)
+        if src is not None:
+            return get_row_name(src)
+
+    type_name = type(gen_inst).__qualname__
+    if type_name not in _warned_missing_task_name:
+        _warned_missing_task_name.add(type_name)
+        logging.getLogger(__name__).warning(
+            "get_row_name: could not find 'task_name' on '%s' or its SRC_DATA; "
+            "task_name will be missing from structured logs and lifecycle events.",
+            type_name,
+        )
+    return None
 
 
 # ===========================================================================
@@ -444,6 +474,72 @@ class Block:
             transformed_outputs = type(inputs)(transformed_outputs)
 
         return transformed_outputs
+
+    async def acall(
+        self,
+        inputs: DATASET_TYPE,
+        *args,
+        input_map: List | Dict | None = None,
+        output_map: List | Dict | None = None,
+        **kwargs,
+    ) -> DATASET_TYPE:
+        """Async variant of ``__call__``.
+
+        Applies the same input/output mapping as ``__call__`` but runs
+        ``execute`` in a thread pool via ``asyncio.to_thread`` so the event
+        loop is not blocked.  Subclasses with native async implementations
+        (e.g. ``LMProvider``) may override ``aexecute`` to avoid the thread
+        hop entirely.
+
+        Args:
+            inputs (DATASET_TYPE): Dataset to be processed.
+            input_map (Optional[Union[List, Dict]]): Override for instance-level input map.
+            output_map (Optional[Union[List, Dict]]): Override for instance-level output map.
+
+        Returns:
+            DATASET_TYPE: Dataset resulting from processing in ``execute``.
+        """
+        input_map = input_map or self._input_map
+        output_map = output_map or self._output_map
+
+        transformed_inputs = list(map(lambda x: self.transform_input(x, input_map), inputs))
+
+        outputs = await self.aexecute(transformed_inputs, *args, **kwargs)
+
+        transformed_outputs = map(lambda x: self.transform_output(x, output_map), outputs)
+        if isinstance(inputs, (list, tuple)):
+            transformed_outputs = type(inputs)(transformed_outputs)
+
+        return transformed_outputs
+
+    async def aexecute(
+        self,
+        inputs: DATASET_TYPE,
+        *args,
+        **kwargs,
+    ) -> DATASET_TYPE:
+        """Async variant of ``execute``.
+
+        The default implementation offloads the synchronous ``execute`` to a
+        thread pool via ``asyncio.to_thread``, which is safe for any subclass
+        whose ``execute`` does not itself schedule work on the running event
+        loop.  Subclasses with a native async implementation may override this
+        method directly.
+
+        Args:
+            inputs (DATASET_TYPE): Pre-transformed inputs (output of ``transform_input``).
+
+        Returns:
+            DATASET_TYPE: Results as returned by ``execute``.
+
+        TODO: Override ``aexecute`` in ``LMProvider`` to drive
+        ``_execute_requests`` directly on the caller's event loop, eliminating
+        the ``asyncio.to_thread`` hop and the internal ``run_async`` /
+        ``run_coroutine_threadsafe`` round-trip.  Requires refactoring
+        ``completion`` / ``chat_completion`` in each provider so the async
+        path is callable without going through the sync wrapper.
+        """
+        return await asyncio.to_thread(self.execute, inputs, *args, **kwargs)
 
     @abstractmethod
     def execute(

--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -27,6 +27,7 @@ from fms_dgt.constants import (
     DATASET_TYPE,
     DGT_DIR,
     STORE_NAME_KEY,
+    TASK_NAME_KEY,
     TYPE_KEY,
 )
 
@@ -59,16 +60,16 @@ def get_row_name(gen_inst: DATASET_ROW_TYPE) -> str | None:
         str | None: Name of task, or None if not found.
     """
     if isinstance(gen_inst, dict):
-        if "task_name" in gen_inst:
-            return gen_inst["task_name"]
-        src = gen_inst.get("SRC_DATA")
+        if TASK_NAME_KEY in gen_inst:
+            return gen_inst[TASK_NAME_KEY]
+        src = gen_inst.get(_SRC_DATA)
         if src is not None:
             return get_row_name(src)
     else:
-        task_name = getattr(gen_inst, "task_name", None)
+        task_name = getattr(gen_inst, TASK_NAME_KEY, None)
         if task_name is not None:
             return task_name
-        src = getattr(gen_inst, "SRC_DATA", None)
+        src = getattr(gen_inst, _SRC_DATA, None)
         if src is not None:
             return get_row_name(src)
 

--- a/fms_dgt/base/concurrency.py
+++ b/fms_dgt/base/concurrency.py
@@ -1,0 +1,162 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Dict, Optional
+import asyncio
+import hashlib
+import threading
+
+
+class _DualSemaphore:
+    """A semaphore that works in both threading and asyncio contexts.
+
+    - Sync callers (the main thread running ``LMProvider.run_async``) acquire
+      via the threading semaphore.
+    - Async callers (coroutines running on the persistent event loop) acquire
+      via the asyncio semaphore.
+
+    Both semaphores are initialised with the same ``value`` so the effective
+    concurrency limit is ``value`` regardless of which interface is used.
+
+    In practice, DGT's current sync runner uses only the threading path.
+    The async path is available for future ``acall``-based consumers (Phase 2).
+    """
+
+    def __init__(self, value: int) -> None:
+        self._value = value
+        self._threading_sem = threading.Semaphore(value)
+        # asyncio.Semaphore must be created on the event loop that will use it;
+        # we defer creation until first async acquisition.
+        self._async_sem: Optional[asyncio.Semaphore] = None
+        self._async_sem_lock = threading.Lock()
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    def _get_async_sem(self) -> asyncio.Semaphore:
+        """Return (lazily creating) the asyncio semaphore."""
+        if self._async_sem is None:
+            with self._async_sem_lock:
+                if self._async_sem is None:
+                    self._async_sem = asyncio.Semaphore(self._value)
+        return self._async_sem
+
+    # ------------------------------------------------------------------
+    # Sync interface (threading)
+    # ------------------------------------------------------------------
+
+    def acquire(self) -> bool:
+        return self._threading_sem.acquire()
+
+    def release(self) -> None:
+        self._threading_sem.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *_):
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Async interface (asyncio)
+    # ------------------------------------------------------------------
+
+    async def async_acquire(self) -> None:
+        await self._get_async_sem().acquire()
+
+    async def async_release(self) -> None:
+        self._get_async_sem().release()
+
+    async def __aenter__(self):
+        await self.async_acquire()
+        return self
+
+    async def __aexit__(self, *_):
+        await self.async_release()
+
+
+class CredentialPool:
+    """Maintains one ``_DualSemaphore`` per unique credential.
+
+    The pool key is a SHA-256 hash of the credential string (typically an API
+    key), so the raw credential is never stored.  All LLM blocks that share
+    the same credential share a single semaphore, enforcing a global
+    ``max_concurrent_requests`` limit across all blocks for that credential.
+
+    Usage (sync)::
+
+        pool = CredentialPool.get_instance()
+        sem = pool.get(api_key, max_concurrent_requests=20)
+        with sem:
+            # at most 20 concurrent threads reach here for this credential
+            ...
+
+    Usage (async)::
+
+        pool = CredentialPool.get_instance()
+        sem = pool.get(api_key, max_concurrent_requests=20)
+        async with sem:
+            ...
+
+    The ``max_concurrent_requests`` argument is only respected on first
+    creation of the semaphore for a given credential.  Subsequent calls with
+    the same credential return the existing semaphore regardless of the
+    ``max_concurrent_requests`` value passed.
+    """
+
+    _instance: Optional["CredentialPool"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._pool: Dict[str, _DualSemaphore] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Singleton access
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_instance(cls) -> "CredentialPool":
+        """Return the process-wide singleton CredentialPool."""
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset(cls) -> None:
+        """Discard the singleton (useful in tests)."""
+        with cls._instance_lock:
+            cls._instance = None
+
+    # ------------------------------------------------------------------
+    # Pool access
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _hash(credential: str) -> str:
+        return hashlib.sha256(credential.encode()).hexdigest()
+
+    def get(self, credential: str, max_concurrent_requests: int = 10) -> _DualSemaphore:
+        """Return the semaphore for ``credential``, creating it if necessary.
+
+        Args:
+            credential: The API key or other credential string.  Only its hash
+                is stored; the raw value is not retained.
+            max_concurrent_requests: Concurrency limit.  Only applied when the
+                semaphore is first created for this credential.
+
+        Returns:
+            A ``_DualSemaphore`` shared by all callers with the same
+            credential.
+        """
+        key = self._hash(credential)
+        if key not in self._pool:
+            with self._lock:
+                if key not in self._pool:
+                    self._pool[key] = _DualSemaphore(max_concurrent_requests)
+        return self._pool[key]

--- a/fms_dgt/base/data_objects.py
+++ b/fms_dgt/base/data_objects.py
@@ -97,12 +97,10 @@ class TaskRunnerConfig:
     Attributes:
         output_dir (Optional[str]): The directory where the generated outputs will be saved.
         save_formatted_output (Optional[bool]): A boolean indicating whether to save outputs that have been reformatted
-        restart_generation (Optional[bool]): A boolean indicating whether to restart generation from scratch.
     """
 
     output_dir: str | None = None
     save_formatted_output: bool | None = False
-    restart_generation: bool | None = False
 
     def __post_init__(self):
         if self.output_dir is None:
@@ -114,11 +112,14 @@ class GenerationTaskRunnerConfig(TaskRunnerConfig):
     """Configuration for a generation task
 
     Attributes:
+        restart_generation (Optional[bool]): Wipe all intermediate data and restart generation from scratch.
+            Not applicable to transformation tasks, which always do a full pass over their input.
         seed_batch_size (Optional[int]): The batch size used for seed examples.
         machine_batch_size (Optional[int]): The batch size used for machine examples.
         num_outputs_to_generate (Optional[int]): The number of outputs to generate.
     """
 
+    restart_generation: bool | None = False
     seed_batch_size: int | None = None
     machine_batch_size: int | None = None
     num_outputs_to_generate: int | None = None

--- a/fms_dgt/base/datastore.py
+++ b/fms_dgt/base/datastore.py
@@ -59,6 +59,30 @@ class Datastore:
     #                       FUNCTIONS
     # ===========================================================================
     @abstractmethod
+    def exists(self) -> bool:
+        """Return True if this store has previously persisted data.
+
+        Used to probe for stale stores (e.g. ``postproc_data_N`` from a prior
+        run) without relying on filesystem-specific APIs.
+        """
+        raise NotImplementedError(
+            f"Missing implementation in {self.__module__}.{self.__class__.__name__}"
+        )
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all previously stored data for this store.
+
+        Subclasses should call this at the end of their own ``__init__`` when
+        ``self._restart`` is True (after their own state is fully initialised).
+        Implementations must be idempotent: calling ``clear()`` on a store that
+        does not yet exist must succeed without raising an error.
+        """
+        raise NotImplementedError(
+            f"Missing implementation in {self.__module__}.{self.__class__.__name__}"
+        )
+
+    @abstractmethod
     def save_data(self, data_to_save: DATASET_TYPE) -> None:
         """
         Saves generated data to specified location

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -107,7 +107,10 @@ class Task:
         self._runner_config = init_dataclass_from_dict(runner_config, TaskRunnerConfig)
         self._output_dir = self._runner_config.output_dir
         self._save_formatted_output = self._runner_config.save_formatted_output
-        self._restart_generation = self._runner_config.restart_generation
+        # Subclasses that support restart (GenerationTask) set this in their own
+        # __init__ after calling super(). Transformation tasks always do a full
+        # pass so they never restart.
+        self._restart_generation: bool = False
 
         # Initialize necessary state variables
         self._post_proc_id = 0  # Tracks Post processor IDs
@@ -116,27 +119,19 @@ class Task:
         # Determine store name from __init__ OR datastore's property, if defined OR task's name
         self._store_name = store_name or (datastore or dict()).pop("store_name", None) or self._name
 
-        # Datastore configurations
-        self._minimum_datastore_config = {
-            "restart": self.restart_generation,
-            "output_dir": self._output_dir,
-        }
-        self._datastore_cfg = {
-            **self._minimum_datastore_config,
-            **(datastore if datastore is not None else {TYPE_KEY: "default"}),
-        }
-        self._final_datastore_config = {
-            **self._minimum_datastore_config,
-            **(final_datastore if final_datastore is not None else self._datastore_cfg),
-        }
-        self._formatted_datastore_config = {
-            **self._minimum_datastore_config,
-            **(formatted_datastore if formatted_datastore is not None else self._datastore_cfg),
-        }
-        self._task_card_datastore_cfg = {
-            **self._minimum_datastore_config,
-            **self._datastore_cfg,
-        }
+        # Store raw datastore kwargs for each store type. _post_init() merges
+        # these with _minimum_datastore_config (which includes the correct
+        # restart flag) once subclasses have finished their own setup.
+        self._minimum_datastore_config: dict = {}
+        _ds_extra = datastore if datastore is not None else {TYPE_KEY: "default"}
+        self._datastore_cfg = dict(_ds_extra)
+        self._final_datastore_config = dict(
+            final_datastore if final_datastore is not None else _ds_extra
+        )
+        self._formatted_datastore_config = dict(
+            formatted_datastore if formatted_datastore is not None else _ds_extra
+        )
+        self._task_card_datastore_cfg = dict(_ds_extra)
 
         # Datastores
         self._intermediate_data_datastore: Datastore = None
@@ -153,7 +148,50 @@ class Task:
             else None
         )
 
-        # Save task card, initialize datastores and logger
+    def _post_init(self):
+        """Finalise datastore configs and initialise stores + logger.
+
+        Called by each concrete subclass at the end of its own ``__init__``,
+        after all subclass-specific state (notably ``_restart_generation``) has
+        been set.  Separating this from ``Task.__init__`` ensures that
+        ``_minimum_datastore_config`` is built with the correct restart flag.
+        """
+        self._minimum_datastore_config = {
+            "restart": self._restart_generation,
+            "output_dir": self._output_dir,
+        }
+        self._datastore_cfg = {
+            **self._minimum_datastore_config,
+            **{
+                k: v
+                for k, v in self._datastore_cfg.items()
+                if k not in self._minimum_datastore_config
+            },
+        }
+        self._final_datastore_config = {
+            **self._minimum_datastore_config,
+            **{
+                k: v
+                for k, v in self._final_datastore_config.items()
+                if k not in self._minimum_datastore_config
+            },
+        }
+        self._formatted_datastore_config = {
+            **self._minimum_datastore_config,
+            **{
+                k: v
+                for k, v in self._formatted_datastore_config.items()
+                if k not in self._minimum_datastore_config
+            },
+        }
+        self._task_card_datastore_cfg = {
+            **self._minimum_datastore_config,
+            **{
+                k: v
+                for k, v in self._task_card_datastore_cfg.items()
+                if k not in self._minimum_datastore_config
+            },
+        }
         self._save_task_card()
         self._init_datastores()
         self._init_logger()
@@ -305,7 +343,38 @@ class Task:
         task_card_datastore.save_data([self.task_card.to_dict()])
         task_card_datastore.close()
 
+    def _clear_stale_postproc_datastores(self):
+        """Clear postproc_data_N stores left over from a previous run.
+
+        On restart we don't know how many post-processing epochs the prior run
+        produced, so we probe N=1,2,3,... calling clear() on each until we
+        reach one that had nothing to clear (i.e. no prior run wrote it).
+        This uses the datastore abstraction so it works for any backend.
+        """
+        n = 1
+        while True:
+            ds = get_datastore(
+                self._datastore_cfg.get(TYPE_KEY),
+                **{
+                    "store_name": os.path.join(self._store_name, f"postproc_data_{n}"),
+                    **self._datastore_cfg,
+                    "restart": False,  # we call clear() ourselves below
+                },
+            )
+            if not ds.exists():
+                break
+            ds.clear()
+            n += 1
+
     def _init_datastores(self):
+        # When restarting, wipe any postproc_data_N stores from the prior run
+        # before initialising the current run's datastores.  Without this a
+        # user inspecting the output directory would see stale postproc_data_5
+        # files alongside the current run's postproc_data_1 / postproc_data_2,
+        # with no way to tell which epoch count is authoritative.
+        if self._restart_generation:
+            self._clear_stale_postproc_datastores()
+
         # Initialize datastore to save intermediate generated/transformed data
         self._intermediate_data_datastore = get_datastore(
             self._datastore_cfg.get(TYPE_KEY),
@@ -583,7 +652,13 @@ class GenerationTask(Task):
             **kwargs,
         )
 
-        # Extract required variables from the runner configuration
+        # restart_generation lives on GenerationTaskRunnerConfig (not the base
+        # TaskRunnerConfig) because it is meaningless for transformation tasks.
+        # Set it before _post_init() so datastores are initialised with the
+        # correct restart flag.
+        self._restart_generation = self.runner_config.restart_generation
+        self._post_init()
+
         self._seed_batch_size = self.runner_config.seed_batch_size
         self._machine_batch_size = self.runner_config.machine_batch_size
         self._num_outputs_to_generate = self.runner_config.num_outputs_to_generate
@@ -781,6 +856,11 @@ class TransformationTask(Task):
             runner_config=init_dataclass_from_dict(runner_config, TransformationTaskRunnerConfig),
             **kwargs,
         )
+
+        # _restart_generation stays False (set by Task.__init__); call _post_init()
+        # now so datastores and logger are ready before the transformation-specific
+        # setup below.
+        self._post_init()
 
         # Extract required variables from the runner configuration
         self._transform_batch_size = self._runner_config.transform_batch_size

--- a/fms_dgt/base/task.py
+++ b/fms_dgt/base/task.py
@@ -19,7 +19,7 @@ from fms_dgt.base.datastore import Datastore
 from fms_dgt.base.formatter import Formatter
 from fms_dgt.base.registry import get_dataloader, get_datastore, get_formatter
 from fms_dgt.base.task_card import TaskRunCard
-from fms_dgt.constants import TYPE_KEY
+from fms_dgt.constants import TASK_NAME_KEY, TYPE_KEY
 from fms_dgt.log import LogDatastoreHandler
 from fms_dgt.utils import (
     group_data_by_attribute,
@@ -45,7 +45,7 @@ def group_data_by_task(data_list: List[T]) -> List[List[T]]:
     Returns:
         List[List[T]]: DataPoint that has been grouped into tasks
     """
-    return group_data_by_attribute(data_list, "task_name")
+    return group_data_by_attribute(data_list, TASK_NAME_KEY)
 
 
 # ===========================================================================

--- a/fms_dgt/base/telemetry.py
+++ b/fms_dgt/base/telemetry.py
@@ -29,6 +29,88 @@ def _telemetry_dir() -> str:
     return os.environ.get("DGT_TELEMETRY_DIR", os.path.join(DGT_DIR, "telemetry"))
 
 
+def payload_recording_enabled() -> bool:
+    """Return True when ``DGT_TELEMETRY_RECORD_PAYLOADS=1`` is set."""
+    val = os.environ.get("DGT_TELEMETRY_RECORD_PAYLOADS", "").strip().lower()
+    return val in ("1", "true", "yes")
+
+
+def payload_max_chars() -> int:
+    """Maximum characters to record per payload field (default 4096)."""
+    try:
+        return int(os.environ.get("DGT_TELEMETRY_PAYLOAD_MAX_CHARS", "4096"))
+    except ValueError:
+        return 4096
+
+
+def truncate_payload(text: str, max_chars: int) -> tuple[str, bool]:
+    """Truncate *text* to *max_chars* characters.
+
+    Returns:
+        A ``(truncated_text, was_truncated)`` tuple.
+    """
+    if len(text) <= max_chars:
+        return text, False
+    return text[:max_chars], True
+
+
+def record_llm_payload(
+    span_attrs: Dict[str, Any],
+    method: str,
+    max_chars: int,
+    *,
+    prompt: Optional[str] = None,
+    messages: Optional[list] = None,
+    response_completion: "str | dict | None" = None,
+) -> None:
+    """Record LLM request/response payloads into *span_attrs* with truncation.
+
+    Args:
+        span_attrs: Mutable dict yielded by ``_llm_span``; keys are written in-place.
+        method: ``"completion"`` or ``"chat_completion"``.
+        max_chars: Maximum characters per string field (from ``payload_max_chars()``).
+        prompt: Raw prompt string (completion mode only).
+        messages: Raw messages list (chat_completion mode only).
+        response_completion: The completion to record. Pass a string for text
+            completions, or a dict for tool-call / structured responses (the
+            ``content`` key is truncated; ``tool_calls`` are preserved as-is).
+    """
+    trunc_flags = []
+
+    if method == "completion" and prompt is not None:
+        trunc_text, was_trunc = truncate_payload(prompt, max_chars)
+        span_attrs["prompt"] = trunc_text
+        trunc_flags.append(was_trunc)
+
+    elif method == "chat_completion" and messages is not None:
+        serialized = []
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                trunc_content, was_trunc = truncate_payload(content, max_chars)
+                trunc_flags.append(was_trunc)
+                serialized.append({**msg, "content": trunc_content})
+            else:
+                serialized.append(msg)
+        span_attrs["messages"] = serialized
+
+    if response_completion is not None:
+        if isinstance(response_completion, str):
+            trunc_text, was_trunc = truncate_payload(response_completion, max_chars)
+            span_attrs["completion"] = trunc_text
+            trunc_flags.append(was_trunc)
+        else:
+            result = dict(response_completion)
+            if isinstance(result.get("content"), str):
+                trunc_content, was_trunc = truncate_payload(result["content"], max_chars)
+                result["content"] = trunc_content
+                trunc_flags.append(was_trunc)
+            span_attrs["completion"] = result
+
+    if any(trunc_flags):
+        span_attrs["payload_truncated"] = True
+
+
 # ===========================================================================
 #                       OTel SDK — optional import
 # ===========================================================================

--- a/fms_dgt/core/blocks/llm/anthropic.py
+++ b/fms_dgt/core/blocks/llm/anthropic.py
@@ -4,21 +4,23 @@
 # Standard
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, List, Literal, Tuple
-import asyncio
 import logging
 
 # Third Party
-from tqdm import tqdm
 import anthropic
 
 # Local
 from fms_dgt.base.registry import get_resource, register_block
-from fms_dgt.constants import BASE_LOGGER_NAME, NOT_GIVEN, NotGiven
+from fms_dgt.base.telemetry import (
+    payload_max_chars,
+    payload_recording_enabled,
+    record_llm_payload,
+)
+from fms_dgt.constants import NOT_GIVEN, NotGiven
 from fms_dgt.core.blocks.llm import LMBlockData, LMProvider, Parameters, ToolChoice
+from fms_dgt.core.blocks.llm.executor import AsyncLLMExecutor
 from fms_dgt.core.blocks.llm.utils import remap, retry
 from fms_dgt.core.resources.api import ApiKeyResource
-
-_logger = logging.getLogger(BASE_LOGGER_NAME)
 
 # Disable third party logging
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -88,13 +90,6 @@ class AnthropicChatCompletionParameters(Parameters):
 # ===========================================================================
 #                       HELPER FUNCTIONS
 # ===========================================================================
-@retry(
-    on_exceptions=(anthropic.AnthropicError,),
-    max_retries=3,
-    on_exception_callback=lambda e, sleep_timer: _logger.warning(
-        "Retrying in %d seconds due to %s: %s", sleep_timer, type(e).__name__, e.args[0]
-    ),
-)
 async def invoke_completion(
     client: anthropic.AsyncAnthropic,
     model: str,
@@ -102,7 +97,7 @@ async def invoke_completion(
     **kwargs,
 ) -> anthropic.types.completion.Completion:
     """
-    Invoke Anthropic legacy completion endopint.
+    Invoke Anthropic legacy completion endpoint.
 
     Args:
         client (anthropic.AsyncAnthropic): Async Anthropic client
@@ -117,13 +112,6 @@ async def invoke_completion(
     )
 
 
-@retry(
-    on_exceptions=(anthropic.AnthropicError,),
-    max_retries=3,
-    on_exception_callback=lambda e, sleep_timer: _logger.warning(
-        "Retrying in %d seconds due to %s: %s", sleep_timer, type(e).__name__, e.args[0]
-    ),
-)
 async def invoke_chat_completion(
     client: anthropic.AsyncAnthropic,
     model: str,
@@ -209,8 +197,11 @@ class Anthropic(LMProvider):
             "api", key_name="ANTHROPIC_API_KEY", call_limit=call_limit
         )
 
-        # Initialize OpenAI clients
+        # Initialize Anthropic async client
         self.async_client = anthropic.AsyncAnthropic(api_key=api_resource.key, timeout=timeout)
+
+        # Register with the credential-based semaphore pool
+        self._init_semaphore(credential=api_resource.key, max_concurrent_requests=call_limit)
 
     # ===========================================================================
     #                       PROPERTIES
@@ -296,56 +287,56 @@ class Anthropic(LMProvider):
 
             return top_logprobs
 
-    async def async_executor(
+    async def _process_item(
         self,
-        queue: asyncio.Queue,
-        update_progress_tracker: Callable,
+        instance: LMBlockData,
+        update_progress: Callable,
         method: str = LMProvider.COMPLETION,
     ):
-        """
-        Execute text completion or chat completion asynchronously.
+        """Process one LMBlockData instance via the Anthropic API.
 
         Args:
-            queue (asyncio.Queue): instances to complete.
-            update_progress_tracker (Callable): progress tracker update function
-            method (str, optional): Either "completion" or "chat_completion". Defaults to LMProvider.COMPLETION.
-
-        Raises:
-            ValueError: If method outside "completion" or "chat_completion" is passed
-            RuntimeError: If number of responses does not match number of inputs * n
+            instance: The request to process.
+            update_progress: Zero-argument callable to advance the progress bar.
+            method: ``LMProvider.COMPLETION`` or ``LMProvider.CHAT_COMPLETION``.
         """
-        while not queue.empty():
-            # Get a "work item" out of the queue.
-            instance = await queue.get()
+        params = (
+            self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
+        ).to_params(instance.gen_kwargs)
 
-            # Extract parameters
-            params = (
-                self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
-            ).to_params(instance.gen_kwargs)
+        invoke_with_retry = retry(
+            on_exceptions=(anthropic.AnthropicError,),
+            max_retries=3,
+            on_exception_callback=lambda e, t: self.logger.warning(
+                "Retrying in %d seconds due to %s: %s", t, type(e).__name__, e.args[0]
+            ),
+        )
 
-            # Trigger appropriate functions
+        async with self._llm_span(method=method, batch_size=1, params=params) as span_attrs:
             if method == self.CHAT_COMPLETION:
-                response = await invoke_chat_completion(
+                messages = self._prepare_input(
+                    instance,
+                    method=method,
+                    max_tokens=params.get("max_tokens", None),
+                )
+                response = await invoke_with_retry(invoke_chat_completion)(
                     client=self.async_client,
                     model=self.model_id_or_path,
-                    messages=self._prepare_input(
-                        instance,
-                        method=method,
-                        max_tokens=params.get("max_tokens", None),
-                    ),
+                    messages=messages,
                     tools=instance.tools,
                     tool_choice=instance.tool_choice,
                     **params,
                 )
             elif method == self.COMPLETION:
-                response = await invoke_completion(
+                prompt = self._prepare_input(
+                    instance,
+                    method=self.COMPLETION,
+                    max_tokens=params.get("max_tokens_to_sample", None),
+                )
+                response = await invoke_with_retry(invoke_completion)(
                     client=self.async_client,
                     model=self.model_id_or_path,
-                    prompt=self._prepare_input(
-                        instance,
-                        method=self.COMPLETION,
-                        max_tokens=params.get("max_tokens_to_sample", None),
-                    ),
+                    prompt=prompt,
                     **params,
                 )
             else:
@@ -353,24 +344,36 @@ class Anthropic(LMProvider):
                     f'Unsupported method ({method}). Only "{self.COMPLETION}" or "{self.CHAT_COMPLETION}" values are allowed.'
                 )
 
-            # Add output
-            self.update_instance_with_result(
-                method,
-                self._extract_choice_content(response, method=method),
-                instance,
-                params.get("stop", None),
-                {
-                    "completion_tokens": response.usage.output_tokens,
-                    "prompt_tokens": response.usage.input_tokens,
-                    "token_logprobs": [],
-                },
-            )
+            span_attrs["prompt_tokens"] = response.usage.input_tokens
+            span_attrs["completion_tokens"] = response.usage.output_tokens
 
-            # Notify the queue that the "work item" has been processed.
-            queue.task_done()
+            if payload_recording_enabled():
+                if method == self.CHAT_COMPLETION:
+                    rc = self._extract_choice_content(response, method=method)
+                else:
+                    rc = response.completion
+                record_llm_payload(
+                    span_attrs,
+                    method,
+                    payload_max_chars(),
+                    prompt=prompt if method == self.COMPLETION else None,
+                    messages=messages if method == self.CHAT_COMPLETION else None,
+                    response_completion=rc,
+                )
 
-            # Update progress tracker
-            update_progress_tracker()
+        self.update_instance_with_result(
+            method,
+            self._extract_choice_content(response, method=method),
+            instance,
+            params.get("stop", None),
+            {
+                "completion_tokens": response.usage.output_tokens,
+                "prompt_tokens": response.usage.input_tokens,
+                "token_logprobs": [],
+            },
+        )
+
+        update_progress(1)
 
     async def _execute_requests(
         self,
@@ -379,33 +382,14 @@ class Anthropic(LMProvider):
         method: str = LMProvider.COMPLETION,
         **kwargs,
     ):
-        # Initialize necessary variables
-        queue = asyncio.Queue()
-
-        # Add to queue
-        for instance in requests:
-            queue.put_nowait(instance)
-
-        # Initialize progress tracker
-        pbar = tqdm(
-            total=len(requests),
-            disable=disable_tqdm,
-            desc=f"Running {method} requests",
+        await AsyncLLMExecutor.run(
+            work_items=requests,
+            process_item=lambda item, upd: self._process_item(item, upd, method=method),
+            call_limit=self._call_limit,
+            total_requests=len(requests),
+            method=method,
+            disable_tqdm=disable_tqdm,
         )
-
-        # Create generate tasks
-        executors = []
-        for _ in range(min(queue.qsize(), self._call_limit)):
-            executors.append(
-                self.async_executor(
-                    queue,
-                    update_progress_tracker=lambda: pbar.update(1),
-                    method=method,
-                )
-            )
-
-        # Wait until all worker are finished
-        await asyncio.gather(*executors, return_exceptions=True)
 
     # ===========================================================================
     #                       MAIN FUNCTIONS
@@ -418,7 +402,7 @@ class Anthropic(LMProvider):
     def chat_completion(
         self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs
     ) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_requests(
                 requests=requests,
                 disable_tqdm=disable_tqdm,

--- a/fms_dgt/core/blocks/llm/executor.py
+++ b/fms_dgt/core/blocks/llm/executor.py
@@ -1,0 +1,74 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import Any, Callable, Iterable
+import asyncio
+
+# Third Party
+from tqdm import tqdm
+
+
+class AsyncLLMExecutor:
+    """Shared async queue-and-worker scaffolding for LLM providers.
+
+    Each provider supplies:
+    - ``work_items``: an iterable of items to enqueue (batches or individual
+      instances, depending on the provider and method).
+    - ``process_item``: an async callable ``(item, update_progress) -> None``
+      that performs the LLM call and writes results back into the
+      ``LMBlockData`` objects it receives.  ``update_progress`` is a
+      zero-argument callable that advances the progress bar; the callee
+      decides *how much* to advance (1 for single-instance modes, batch_size
+      for batched modes).
+
+    The executor owns queue construction, worker spawning (bounded by
+    ``call_limit``), the progress bar, and ``asyncio.gather``.  Retry logic
+    belongs in ``process_item`` (decorated with ``@retry`` at the call site).
+    """
+
+    @staticmethod
+    async def run(
+        work_items: Iterable[Any],
+        process_item: Callable[[Any, Callable[[], None]], Any],
+        call_limit: int,
+        total_requests: int,
+        method: str,
+        disable_tqdm: bool = False,
+    ) -> None:
+        """Drive concurrent LLM calls through a shared async queue.
+
+        Args:
+            work_items: Items to enqueue (batches or single ``LMBlockData``
+                instances).
+            process_item: ``async callable(item, update_progress) -> None``.
+                Must write results back into the ``LMBlockData`` objects it
+                receives and call ``update_progress()`` once per work item
+                processed.
+            call_limit: Maximum number of concurrent worker coroutines.
+            total_requests: Total number of *requests* used for the progress
+                bar.  For batched modes this equals the number of individual
+                prompts, not the number of queue items.
+            method: Human-readable method name shown in the progress bar.
+            disable_tqdm: Suppress the progress bar.
+        """
+        queue: asyncio.Queue = asyncio.Queue()
+        for item in work_items:
+            queue.put_nowait(item)
+
+        pbar = tqdm(
+            total=total_requests,
+            disable=disable_tqdm,
+            desc=f"Running {method} requests",
+        )
+
+        async def _worker() -> None:
+            while not queue.empty():
+                item = await queue.get()
+                await process_item(item, pbar.update)
+                queue.task_done()
+
+        n_workers = min(queue.qsize(), call_limit)
+        await asyncio.gather(*[_worker() for _ in range(n_workers)], return_exceptions=True)
+
+        pbar.close()

--- a/fms_dgt/core/blocks/llm/llm.py
+++ b/fms_dgt/core/blocks/llm/llm.py
@@ -2,12 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, fields
-from typing import Any, Dict, Iterable, List, Literal, Tuple
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 import abc
+import asyncio
+import contextvars
 import hashlib
 import json
 import os
+import threading
+import time
 
 # Third Party
 from sqlitedict import SqliteDict
@@ -16,6 +21,11 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 
 # Local
 from fms_dgt.base.block import DATASET_TYPE, Block, BlockData
+from fms_dgt.base.concurrency import CredentialPool, _DualSemaphore
+from fms_dgt.base.telemetry import (
+    Span,
+    payload_recording_enabled,
+)
 from fms_dgt.constants import NOT_GIVEN, NotGiven
 
 MODEL_ID_OR_PATH = "model_id_or_path"
@@ -85,6 +95,9 @@ class LMProvider(Block):
     COMPLETION = "completion"
     CHAT_COMPLETION = "chat_completion"
 
+    # Emitted at most once per process to avoid log spam.
+    _payload_warning_emitted: bool = False
+
     def __new__(cls, *args: Any, **kwargs: Any):
         if "lm_cache" in kwargs and cls is not CachingLM:
             kwargs = dict(kwargs)
@@ -124,6 +137,28 @@ class LMProvider(Block):
 
         # Initialize usage tracker in profiler data
         self.profiler_data["usage"] = {"tokens": {"completion": 0, "prompt": 0}}
+
+        # Persistent event loop: created once at init, reused across all calls.
+        # Running on a dedicated daemon thread so it never blocks the caller.
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever, daemon=True, name=f"dgt-lm-loop-{self._name}"
+        )
+        self._loop_thread.start()
+
+        # Credential semaphore: None until a subclass calls _init_semaphore().
+        # When set, every LLM call acquires it to enforce max_concurrent_requests.
+        self._semaphore: Optional[_DualSemaphore] = None
+
+        # Warn once per process when payload recording is on, since it fills
+        # traces.jsonl quickly and should only be used for short debugging runs.
+        if payload_recording_enabled() and not LMProvider._payload_warning_emitted:
+            LMProvider._payload_warning_emitted = True
+            self.logger.warning(
+                "DGT_TELEMETRY_RECORD_PAYLOADS=1 is active: LLM prompts and completions "
+                "will be written to traces.jsonl. Use this only for small debugging runs "
+                "as it fills the telemetry directory quickly."
+            )
 
     # ===========================================================================
     #                       PROPERTIES
@@ -244,6 +279,112 @@ class LMProvider(Block):
     def set_cache_hook(self, cache_hook) -> None:
         self._cache_hook = cache_hook
 
+    def _init_semaphore(self, credential: str, max_concurrent_requests: int = 10) -> None:
+        """Register this provider with the process-wide CredentialPool.
+
+        Call this from a subclass ``__init__`` after the credential is known.
+        All providers sharing the same credential (API key) will share one
+        semaphore, capping total concurrent LLM requests across all of them.
+
+        Args:
+            credential: The API key or other credential string.  Only its hash
+                is stored in the pool.
+            max_concurrent_requests: Concurrency limit for this credential.
+                Only applied on first registration; subsequent calls with the
+                same credential return the existing semaphore.
+        """
+        self._semaphore = CredentialPool.get_instance().get(
+            credential, max_concurrent_requests=max_concurrent_requests
+        )
+
+    @asynccontextmanager
+    async def _llm_span(
+        self,
+        method: str,
+        batch_size: int,
+        params: Dict,
+    ):
+        """Async context manager that wraps one LLM API call with a ``dgt.llm_call`` span.
+
+        Acquires the credential semaphore, then opens a ``Span`` whose
+        ``duration_ms`` reflects only the API call latency (not the wait).
+        The semaphore wait time is recorded as the ``semaphore_wait_ms``
+        attribute on the span.
+
+        Yields a mutable ``attrs`` dict.  The caller must populate:
+        - ``prompt_tokens`` (int)
+        - ``completion_tokens`` (int)
+
+        Optionally (when payload recording is on):
+        - ``prompt`` or ``messages`` (str / list)
+        - ``completion`` (str / dict)
+        - ``payload_truncated`` (bool)
+
+        Args:
+            method: ``"completion"`` or ``"chat_completion"``.
+            batch_size: Number of individual prompts in this work item.
+            params: The resolved generation parameters dict (for extracting
+                ``temperature``, ``n``, ``max_tokens`` / ``max_completion_tokens``).
+        """
+        _temperature = params.get("temperature", None)
+        _n = params.get("n", None)
+        _max_tokens = params.get(
+            "max_tokens",
+            params.get(
+                "max_completion_tokens",
+                params.get("max_new_tokens", params.get("num_predict", None)),
+            ),
+        )
+        attrs: Dict[str, Any] = {
+            "provider": type(self).__name__,
+            "model_id": self.model_id_or_path,
+            "method": method,
+            "batch_size": batch_size,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "semaphore_wait_ms": 0.0,
+        }
+        if _temperature is not None:
+            attrs["temperature"] = _temperature
+        if _n is not None:
+            attrs["n"] = _n
+        if _max_tokens is not None:
+            attrs["max_tokens"] = _max_tokens
+
+        # Measure how long we wait for the semaphore separately from API time.
+        _wait_start = time.monotonic()
+        async with self._semaphore:
+            attrs["semaphore_wait_ms"] = round((time.monotonic() - _wait_start) * 1000, 2)
+            # The Span context manager captures start/end time and writes on exit.
+            # duration_ms therefore equals pure API latency.
+            with Span(
+                "dgt.llm_call",
+                self._span_writer,
+                parent_span_name="dgt.block",
+                **attrs,
+            ) as span:
+                yield attrs
+                # Flush any updates the caller made to attrs into the span record.
+                for k, v in attrs.items():
+                    span.set_attribute(k, v)
+
+    def run_async(self, coro):
+        """Run a coroutine on the persistent event loop and block until it completes.
+
+        Copies the current contextvars context into the loop-thread task so
+        that run_id/build_id from RunContextFilter are visible on log records
+        emitted inside the coroutine.
+        """
+        ctx = contextvars.copy_context()
+
+        async def _with_ctx():
+            # create_task with an explicit context propagates the caller's
+            # contextvars (run_id, build_id) into the coroutine's execution.
+            return await self._loop.create_task(coro, context=ctx)
+
+        future = asyncio.run_coroutine_threadsafe(_with_ctx(), self._loop)
+        return future.result()
+
     def serve(self, *args: Any, **kwargs: Any):
         pass
 
@@ -252,6 +393,9 @@ class LMProvider(Block):
 
     def close(self):
         self.release_model()
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join(timeout=5)
+        self._loop.close()
 
     def update_instance_with_result(
         self,

--- a/fms_dgt/core/blocks/llm/ollama.py
+++ b/fms_dgt/core/blocks/llm/ollama.py
@@ -4,18 +4,22 @@
 # Standard
 from dataclasses import dataclass, fields
 from typing import Any, Callable, Dict, List, Tuple
-import asyncio
 import logging
 
 # Third Party
 from httpx import HTTPError
-from ollama import Client, show
-from tqdm import tqdm
+from ollama import AsyncClient, Client, show
 
 # Local
 from fms_dgt.base.registry import register_block
+from fms_dgt.base.telemetry import (
+    payload_max_chars,
+    payload_recording_enabled,
+    record_llm_payload,
+)
 from fms_dgt.constants import NOT_GIVEN, NotGiven
 from fms_dgt.core.blocks.llm import LMBlockData, LMProvider, Parameters
+from fms_dgt.core.blocks.llm.executor import AsyncLLMExecutor
 from fms_dgt.core.blocks.llm.openai import OpenAI
 from fms_dgt.core.blocks.llm.utils import remap
 
@@ -82,8 +86,9 @@ class Ollama(OpenAI):
         if not self.batch_size or self.batch_size > 1:
             self._batch_size = 1
 
-        # Create Ollama client
+        # Sync client for non-async use; async client for the executor path
         self._client = Client(host=base_url)
+        self._async_client = AsyncClient(host=base_url)
 
     # ===========================================================================
     #                       PROPERTIES
@@ -137,55 +142,50 @@ class Ollama(OpenAI):
         # If choice is generated via text completion
         return choice.response
 
-    async def async_executor(
+    async def _process_item(
         self,
-        queue: asyncio.Queue,
-        update_progress_tracker: Callable,
+        instance: LMBlockData,
+        update_progress: Callable,
         method: str = LMProvider.COMPLETION,
     ):
-        """
-        Execute text completion or chat completion asynchronously.
+        """Process one Ollama request using the native async client.
+
+        Uses ``self._async_client`` so parallel execution actually happens.
+        The sync ``self._client`` is retained for non-async use cases only.
 
         Args:
-            queue (asyncio.Queue): instances to complete.
-            update_progress_tracker (Callable): progress tracker update function
-            method (str, optional): Either "completion" or "chat_completion". Defaults to LMProvider.COMPLETION.
-
-        Raises:
-            ValueError: If method outside "completion" or "chat_completion" is passed
-            RuntimeError: If number of responses does not match number of inputs * n
+            instance: The request to process.
+            update_progress: Zero-argument callable to advance the progress bar.
+            method: ``LMProvider.COMPLETION`` or ``LMProvider.CHAT_COMPLETION``.
         """
-        while not queue.empty():
-            # Get a "work item" out of the queue.
-            instance = await queue.get()
+        params = (
+            self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
+        ).to_params(instance.gen_kwargs)
 
-            # Extract parameters
-            params = (
-                self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
-            ).to_params(instance.gen_kwargs)
-
-            # Trigger OpenAI completion functions
+        async with self._llm_span(method=method, batch_size=1, params=params) as span_attrs:
             if method == self.CHAT_COMPLETION:
-                response = self._client.chat(
+                messages = self._prepare_input(
+                    instance,
+                    method=method,
+                    max_tokens=params.get("num_predict", None),
+                )
+                response = await self._async_client.chat(
                     model=self.model_id_or_path,
-                    messages=self._prepare_input(
-                        instance,
-                        method=method,
-                        max_tokens=params.get("num_predict", None),
-                    ),
+                    messages=messages,
                     tools=instance.tools,
                     options=params,
                     stream=False,
                 )
             elif method == self.COMPLETION:
-                response = self._client.generate(
+                prompt = self._prepare_input(
+                    instance,
+                    method=self.COMPLETION,
+                    max_tokens=params.get("num_predict", None),
+                )
+                response = await self._async_client.generate(
                     model=self._model_id_or_path,
-                    prompt=self._prepare_input(
-                        instance,
-                        method=self.COMPLETION,
-                        max_tokens=params.get("num_predict", None),
-                    ),
-                    options=params,
+                    prompt=prompt,
+                    # options=params,
                     stream=False,
                 )
             else:
@@ -193,24 +193,36 @@ class Ollama(OpenAI):
                     f'Unsupported method ({method}). Only "{self.COMPLETION}" or "{self.CHAT_COMPLETION}" values are allowed.'
                 )
 
-            # Add output
-            self.update_instance_with_result(
-                method,
-                self._extract_choice_content(response, method=method),
-                instance,
-                params.get("stop", None),
-                {
-                    "completion_tokens": response.eval_count,
-                    "prompt_tokens": response.prompt_eval_count,
-                    "token_logprobs": [],
-                },
-            )
+            span_attrs["prompt_tokens"] = response.prompt_eval_count or 0
+            span_attrs["completion_tokens"] = response.eval_count or 0
 
-            # Notify the queue that the "work item" has been processed.
-            queue.task_done()
+            if payload_recording_enabled():
+                if method == self.CHAT_COMPLETION:
+                    rc = response.message.dict()
+                else:
+                    rc = response.response or ""
+                record_llm_payload(
+                    span_attrs,
+                    method,
+                    payload_max_chars(),
+                    prompt=prompt if method == self.COMPLETION else None,
+                    messages=messages if method == self.CHAT_COMPLETION else None,
+                    response_completion=rc,
+                )
 
-            # Update progress tracker
-            update_progress_tracker()
+        self.update_instance_with_result(
+            method,
+            self._extract_choice_content(response, method=method),
+            instance,
+            params.get("stop", None),
+            {
+                "completion_tokens": response.eval_count,
+                "prompt_tokens": response.prompt_eval_count,
+                "token_logprobs": [],
+            },
+        )
+
+        update_progress(1)
 
     async def _execute_requests(
         self,
@@ -219,39 +231,20 @@ class Ollama(OpenAI):
         method: str = LMProvider.COMPLETION,
         **kwargs,
     ):
-        # Initialize necessary variables
-        queue = asyncio.Queue()
-
-        # Add to queue
-        for instance in requests:
-            queue.put_nowait(instance)
-
-        # Initialize progress tracker
-        pbar = tqdm(
-            total=len(requests),
-            disable=disable_tqdm,
-            desc=f"Running {method} requests",
+        await AsyncLLMExecutor.run(
+            work_items=requests,
+            process_item=lambda item, upd: self._process_item(item, upd, method=method),
+            call_limit=self._call_limit,
+            total_requests=len(requests),
+            method=method,
+            disable_tqdm=disable_tqdm,
         )
-
-        # Create generate tasks
-        executors = []
-        for _ in range(min(queue.qsize(), self._call_limit)):
-            executors.append(
-                self.async_executor(
-                    queue,
-                    update_progress_tracker=lambda: pbar.update(1),
-                    method=method,
-                )
-            )
-
-        # Wait until all worker are finished
-        await asyncio.gather(*executors, return_exceptions=True)
 
     # ===========================================================================
     #                       MAIN FUNCTIONS
     # ===========================================================================
     def completion(self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_requests(
                 requests=requests,
                 disable_tqdm=disable_tqdm,
@@ -263,7 +256,7 @@ class Ollama(OpenAI):
     def chat_completion(
         self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs
     ) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_requests(
                 requests=requests,
                 disable_tqdm=disable_tqdm,

--- a/fms_dgt/core/blocks/llm/openai.py
+++ b/fms_dgt/core/blocks/llm/openai.py
@@ -4,21 +4,23 @@
 # Standard
 from dataclasses import asdict, dataclass, fields
 from typing import Any, Callable, Dict, Iterable, List, Literal, Tuple
-import asyncio
 import logging
 
 # Third Party
-from tqdm import tqdm
 import openai
 import tiktoken
 
 # Local
 from fms_dgt.base.registry import get_resource, register_block
-from fms_dgt.constants import BASE_LOGGER_NAME, NOT_GIVEN, NotGiven
+from fms_dgt.base.telemetry import (
+    payload_max_chars,
+    payload_recording_enabled,
+    record_llm_payload,
+)
+from fms_dgt.constants import NOT_GIVEN, NotGiven
 from fms_dgt.core.blocks.llm import LMBlockData, LMProvider, Parameters, ToolChoice
+from fms_dgt.core.blocks.llm.executor import AsyncLLMExecutor
 from fms_dgt.core.blocks.llm.utils import Grouper, chunks, remap, retry
-
-_logger = logging.getLogger(BASE_LOGGER_NAME)
 
 # Disable third party logging
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -98,13 +100,6 @@ class OpenAIChatCompletionParameters(Parameters):
 # ===========================================================================
 #                       HELPER FUNCTIONS
 # ===========================================================================
-@retry(
-    on_exceptions=(openai.OpenAIError,),
-    max_retries=3,
-    on_exception_callback=lambda e, sleep_timer: _logger.warning(
-        "Retrying in %d seconds due to %s: %s", sleep_timer, type(e).__name__, e.args[0]
-    ),
-)
 async def invoke_completion(
     client: openai.AsyncOpenAI,
     model: str,
@@ -112,7 +107,7 @@ async def invoke_completion(
     **kwargs,
 ) -> openai.types.completion.Completion:
     """
-    Invoke OpenAI legacy completion endopint.
+    Invoke OpenAI legacy completion endpoint.
 
     Args:
         client (openai.AsyncOpenAI): Async OpenAI client
@@ -125,13 +120,6 @@ async def invoke_completion(
     return await client.completions.create(model=model, prompt=prompt, **kwargs)
 
 
-@retry(
-    on_exceptions=(openai.OpenAIError,),
-    max_retries=3,
-    on_exception_callback=lambda e, sleep_timer: _logger.warning(
-        "Retrying in %d seconds due to %s: %s", sleep_timer, type(e).__name__, e.args[0]
-    ),
-)
 async def invoke_chat_completion(
     client: openai.AsyncOpenAI,
     model: str,
@@ -148,7 +136,7 @@ async def invoke_chat_completion(
         model (str): OpenAI model name
         messages (List[Dict[str, Any]]): list of messages in the conversation
         tools: List[Dict[str, Any]] | None: list of tool definitions available to the model
-        tool_choice: controls which (if any) tool is called by the model. `none` means the model will not call any tool and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools.`required` means the model must call one or more tools. Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool. `none` is the default when no tools are present. `auto` is the default if tools are present.
+        tool_choice: controls which (if any) tool is called by the model. `none` means the model will not call any tool and instead generates a message. `auto` means the model can pick between generating a message or calling one or more tools. `required` means the model must call one or more tools. Specifying a particular tool via `{"type": "function", "function": {"name": "my_function"}}` forces the model to call that tool. `none` is the default when no tools are present. `auto` is the default if tools are present.
 
     Returns:
         openai.types.completion.Completion: Completion response
@@ -192,16 +180,21 @@ class OpenAI(LMProvider):
         self._call_limit = call_limit
 
         # Step 4: Initialize OpenAI clients
+        resolved_key = (
+            api_key
+            if api_key
+            else get_resource("api", key_name="OPENAI_API_KEY", call_limit=call_limit).key
+        )
         self.async_client = openai.AsyncOpenAI(
-            api_key=(
-                api_key
-                if api_key
-                else get_resource("api", key_name="OPENAI_API_KEY", call_limit=call_limit).key
-            ),
+            api_key=resolved_key,
             timeout=timeout,
             base_url=base_url,
             default_headers=default_headers,
         )
+
+        # Step 5: Register with the credential-based semaphore pool so that all
+        # blocks sharing the same API key share a single concurrency limit.
+        self._init_semaphore(credential=resolved_key, max_concurrent_requests=call_limit)
 
     # ===========================================================================
     #                       HELPER FUNCTIONS
@@ -259,72 +252,76 @@ class OpenAI(LMProvider):
 
             return top_logprobs
 
-    async def async_executor(
+    async def _process_item(
         self,
-        queue: asyncio.Queue,
-        update_progress_tracker: Callable,
+        chunk,
+        update_progress: Callable,
         method: str = LMProvider.COMPLETION,
     ):
-        """
-        Execute text completion or chat completion asynchronously.
-
-        NOTE:
-        - For "chat" completion, queue contains individual conversation to complete
-        - For "text" completion, queue contains batches of prompts that can be passed in a single call
+        """Process one work item (a batch for completion, a single instance for chat).
 
         Args:
-            queue (asyncio.Queue): instances to complete.
-            update_progress_tracker (Callable): progress tracker update function
-            method (str, optional): Either "completion" or "chat_completion". Defaults to LMProvider.COMPLETION.
+            chunk: A list of ``LMBlockData`` for completion mode, or a single
+                ``LMBlockData`` for chat-completion mode.
+            update_progress: Callable ``(int) -> None`` to advance the progress bar.
+            method: ``LMProvider.COMPLETION`` or ``LMProvider.CHAT_COMPLETION``.
 
         Raises:
-            ValueError: If method outside "completion" or "chat_completion" is passed
-            RuntimeError: If number of responses does not match number of inputs * n
+            ValueError: If an unsupported method is passed.
+            RuntimeError: If the number of API responses does not match expected.
         """
-        while not queue.empty():
-            # Step 1: Get a "work item" out of the queue.
-            chunk = await queue.get()
+        # Fetch generation kwargs from 1st request (identical within a chunk)
+        params = next(iter(chunk)).gen_kwargs if isinstance(chunk, Iterable) else chunk.gen_kwargs
 
-            # Step 2: Fetch generation kwargs from 1st request since generation kwargs within a chunk are identical
-            params = (
-                next(iter(chunk)).gen_kwargs if isinstance(chunk, Iterable) else chunk.gen_kwargs
-            )
+        # Extract completion parameters from gen_kwargs
+        params = (
+            self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
+        ).to_params(params)
 
-            # Step 3: Extract completion parameters from gen_kwargs
-            params = (
-                self._chat_parameters if method == self.CHAT_COMPLETION else self._parameters
-            ).to_params(params)
+        # Simplify downstream processing
+        if params.get("logprobs") and params.get("top_logprobs") is None:
+            params["top_logprobs"] = 1
 
-            # adding this here to simplify downstream processing
-            if params.get("logprobs") and params.get("top_logprobs") is None:
-                params["top_logprobs"] = 1
+        invoke_with_retry = retry(
+            on_exceptions=(openai.OpenAIError,),
+            max_retries=3,
+            on_exception_callback=lambda e, t: self.logger.warning(
+                "Retrying in %d seconds due to %s: %s", t, type(e).__name__, e.args[0]
+            ),
+        )
 
-            # Step 4: Trigger OpenAI completion functions
+        batch_size = len(chunk) if isinstance(chunk, Iterable) else 1
+
+        async with self._llm_span(
+            method=method, batch_size=batch_size, params=params
+        ) as span_attrs:
             if method == self.CHAT_COMPLETION:
-                response = await invoke_chat_completion(
+                messages = self._prepare_input(
+                    chunk,
+                    method=self.CHAT_COMPLETION,
+                    max_tokens=params.get("max_completion_tokens", None),
+                )
+                response = await invoke_with_retry(invoke_chat_completion)(
                     client=self.async_client,
                     model=self.model_id_or_path,
-                    messages=self._prepare_input(
-                        chunk,
-                        method=self.CHAT_COMPLETION,
-                        max_tokens=params.get("max_completion_tokens", None),
-                    ),
+                    messages=messages,
                     tools=chunk.tools,
                     tool_choice=chunk.tool_choice,
                     **params,
                 )
             elif method == self.COMPLETION:
-                response = await invoke_completion(
+                prompts = [
+                    self._prepare_input(
+                        instance,
+                        method=self.COMPLETION,
+                        max_tokens=params.get("max_tokens", None),
+                    )
+                    for instance in chunk
+                ]
+                response = await invoke_with_retry(invoke_completion)(
                     client=self.async_client,
                     model=self.model_id_or_path,
-                    prompt=[
-                        self._prepare_input(
-                            instance,
-                            method=self.COMPLETION,
-                            max_tokens=params.get("max_tokens", None),
-                        )
-                        for instance in chunk
-                    ],
+                    prompt=prompts,
                     **params,
                 )
             else:
@@ -332,56 +329,64 @@ class OpenAI(LMProvider):
                     f'Unsupported method ({method}). Only "{self.COMPLETION}" or "{self.CHAT_COMPLETION}" values are allowed.'
                 )
 
-            # Step 5: If multiple choices requested per input
-            # Step 5.a: Get requested choices count from parameters
-            n = params.get("n", 1)
+            # Record token usage in span
+            span_attrs["prompt_tokens"] = response.usage.prompt_tokens
+            span_attrs["completion_tokens"] = response.usage.completion_tokens
 
-            # Step 5.b: Verify enough responses are generated per input
-            if len(response.choices) != n * (len(chunk) if isinstance(chunk, Iterable) else 1):
-                raise RuntimeError(
-                    f"Number of responses does not match number of inputs * n, [{len(response.choices)}, {len(chunk) if isinstance(chunk, Iterable) else 1}, {n}]"
-                )
-
-            # Step 5.c: Group N responses for each request
-            response_choices_per_input = [
-                response.choices[i : i + n] for i in range(0, len(response.choices), n)
-            ]
-            total_outputs = sum([len(x) for x in response_choices_per_input])
-
-            # Step 6: Iterate over each grouped response
-            for response_choices, instance in zip(
-                response_choices_per_input,
-                chunk if isinstance(chunk, Iterable) else [chunk],
-            ):
-                outputs = []
-                addtl = {
-                    "completion_tokens": (response.usage.completion_tokens // total_outputs),
-                    "prompt_tokens": response.usage.prompt_tokens // total_outputs,
-                    "token_logprobs": [],
-                }
-                for choice in response_choices:
-                    outputs.append(self._extract_choice_content(choice, method=method))
-
-                    token_logprobs = self._extract_token_log_probabilities(
-                        choice=choice, method=method
-                    )
-                    if token_logprobs:
-                        addtl["token_logprobs"].append(token_logprobs)
-                        addtl["completion_tokens"] = len(token_logprobs)
-
-                self.update_instance_with_result(
+            if payload_recording_enabled():
+                if method == self.CHAT_COMPLETION:
+                    rc = self._extract_choice_content(response.choices[0], method=method)
+                else:
+                    rc = " ".join(c.text for c in response.choices if hasattr(c, "text"))
+                record_llm_payload(
+                    span_attrs,
                     method,
-                    outputs if len(outputs) > 1 else outputs[0],
-                    instance,
-                    params.get("stop", None),
-                    addtl,
+                    payload_max_chars(),
+                    prompt="\n---\n".join(prompts) if method == self.COMPLETION else None,
+                    messages=messages if method == self.CHAT_COMPLETION else None,
+                    response_completion=rc,
                 )
 
-            # Step 7: Notify the queue that the "work item" has been processed.
-            queue.task_done()
+        # Validate response count
+        n = params.get("n", 1)
+        if len(response.choices) != n * batch_size:
+            raise RuntimeError(
+                f"Number of responses does not match number of inputs * n, [{len(response.choices)}, {batch_size}, {n}]"
+            )
 
-            # Step 8: Update progress tracker
-            update_progress_tracker()
+        # Group N responses per input and write results back
+        response_choices_per_input = [
+            response.choices[i : i + n] for i in range(0, len(response.choices), n)
+        ]
+        total_outputs = sum(len(x) for x in response_choices_per_input)
+
+        for response_choices, instance in zip(
+            response_choices_per_input,
+            chunk if isinstance(chunk, Iterable) else [chunk],
+        ):
+            outputs = []
+            addtl = {
+                "completion_tokens": (response.usage.completion_tokens // total_outputs),
+                "prompt_tokens": response.usage.prompt_tokens // total_outputs,
+                "token_logprobs": [],
+            }
+            for choice in response_choices:
+                outputs.append(self._extract_choice_content(choice, method=method))
+
+                token_logprobs = self._extract_token_log_probabilities(choice=choice, method=method)
+                if token_logprobs:
+                    addtl["token_logprobs"].append(token_logprobs)
+                    addtl["completion_tokens"] = len(token_logprobs)
+
+            self.update_instance_with_result(
+                method,
+                outputs if len(outputs) > 1 else outputs[0],
+                instance,
+                params.get("stop", None),
+                addtl,
+            )
+
+        update_progress(self._batch_size if method == self.COMPLETION else 1)
 
     async def _execute_requests(
         self,
@@ -390,50 +395,30 @@ class OpenAI(LMProvider):
         method: str = LMProvider.COMPLETION,
         **kwargs,
     ):
-        # Step 1: Initialize necessary variables
-        queue = asyncio.Queue()
-
-        # Step 2: Group requests by their generation_kwargs
+        # Build work items: batches for completion, individual instances for chat
+        work_items = []
         grouper = Grouper(requests, lambda x: str(x.gen_kwargs))
-
-        # Step 3: Iterate over each group
         for _, reqs in grouper.get_grouped().items():
-            # Step 3.a: Create request chunks based on maximum allowed batch size and add to queue
             for chunk in chunks(reqs, n=self.batch_size):
                 if method == self.CHAT_COMPLETION:
-                    for instance in chunk:
-                        queue.put_nowait(instance)
+                    work_items.extend(chunk)
                 else:
-                    queue.put_nowait(chunk)
+                    work_items.append(chunk)
 
-        # Step 4: Initialize progress tracker
-        pbar = tqdm(
-            total=len(requests),
-            disable=disable_tqdm,
-            desc=f"Running {method} requests",
+        await AsyncLLMExecutor.run(
+            work_items=work_items,
+            process_item=lambda item, upd: self._process_item(item, upd, method=method),
+            call_limit=self._call_limit,
+            total_requests=len(requests),
+            method=method,
+            disable_tqdm=disable_tqdm,
         )
-
-        # Step 5: Create generate tasks
-        executors = []
-        for _ in range(min(queue.qsize(), self._call_limit)):
-            executors.append(
-                self.async_executor(
-                    queue,
-                    update_progress_tracker=lambda: pbar.update(
-                        self._batch_size if method == self.COMPLETION else 1
-                    ),
-                    method=method,
-                )
-            )
-
-        # Step 6: Wait until all worker are finished
-        await asyncio.gather(*executors, return_exceptions=True)
 
     # ===========================================================================
     #                       MAIN FUNCTIONS
     # ===========================================================================
     def completion(self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_requests(
                 requests=requests,
                 disable_tqdm=disable_tqdm,
@@ -445,7 +430,7 @@ class OpenAI(LMProvider):
     def chat_completion(
         self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs
     ) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_requests(
                 requests=requests,
                 disable_tqdm=disable_tqdm,

--- a/fms_dgt/core/blocks/llm/utils.py
+++ b/fms_dgt/core/blocks/llm/utils.py
@@ -5,6 +5,7 @@
 from functools import wraps
 from inspect import iscoroutinefunction
 from typing import Any, Callable, Optional, Set, Tuple, Type
+import asyncio
 import collections
 import itertools
 import logging
@@ -16,6 +17,29 @@ from fms_dgt.constants import BASE_LOGGER_NAME
 _logger = logging.getLogger(BASE_LOGGER_NAME)
 
 
+def _retry_after_seconds(exc: Exception, backoff_time: float) -> float:
+    """Return how long to wait before the next retry attempt.
+
+    If the exception carries a ``Retry-After`` header (OpenAI and Anthropic
+    both set this on 429 responses via ``httpx.Response``), honour it.
+    Otherwise fall back to the caller-supplied ``backoff_time``.
+
+    Args:
+        exc: The caught exception.
+        backoff_time: Exponential-backoff default (seconds).
+
+    Returns:
+        Seconds to wait before the next attempt.
+    """
+    try:
+        header = exc.response.headers.get("retry-after", None)
+        if header is not None:
+            return float(header)
+    except AttributeError:
+        pass
+    return backoff_time
+
+
 def retry(
     on_exceptions: Tuple[Type[Exception]],
     max_retries: int = 3,
@@ -23,7 +47,12 @@ def retry(
     backoff_multiplier: float = 1.5,
     on_exception_callback: Optional[Callable[[Exception, float], Any]] = None,
 ):
-    """Retry on an LLM Provider's rate limit error with exponential backoff
+    """Retry on an LLM Provider's rate limit error with exponential backoff.
+
+    When the exception carries a ``Retry-After`` header (HTTP 429), that
+    value is used as the wait time instead of the computed backoff so the
+    caller honours the server's guidance exactly.
+
     For example, to use for OpenAI, do the following:
     ```
     from openai import RateLimitError
@@ -39,45 +68,41 @@ def retry(
     def decorator(func: Callable):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Initialize necessary variables
             sleep_timer = backoff_time
             attempt = 0
 
-            # Keep retrying till max retries are attempted
             while attempt < max_retries:
                 try:
                     return func(*args, **kwargs)
                 except on_exceptions as e:
-                    # Trigger exception callback
+                    wait = _retry_after_seconds(e, sleep_timer)
+
                     if on_exception_callback is not None:
-                        on_exception_callback(e, sleep_timer)
+                        on_exception_callback(e, wait)
 
-                    # Wait for sleep timer before retrying
-                    time.sleep(sleep_timer)
+                    time.sleep(wait)
 
-                    # Increament sleep timer and attempt counter
                     sleep_timer *= backoff_multiplier
                     attempt += 1
 
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
-            # Initialize necessary variables
             sleep_timer = backoff_time
             attempt = 0
 
-            # Keep retrying till max retries are attempted
             while attempt < max_retries:
                 try:
                     return await func(*args, **kwargs)
                 except on_exceptions as e:
-                    # Trigger exception callback
+                    wait = _retry_after_seconds(e, sleep_timer)
+
                     if on_exception_callback is not None:
-                        on_exception_callback(e, sleep_timer)
+                        on_exception_callback(e, wait)
 
-                    # Wait for sleep timer before retrying
-                    time.sleep(sleep_timer)
+                    # Use asyncio.sleep so the event loop is not blocked
+                    # while waiting to retry.
+                    await asyncio.sleep(wait)
 
-                    # Increament sleep timer and attempt counter
                     sleep_timer *= backoff_multiplier
                     attempt += 1
 

--- a/fms_dgt/core/blocks/llm/watsonx.py
+++ b/fms_dgt/core/blocks/llm/watsonx.py
@@ -4,7 +4,6 @@
 # Standard
 from dataclasses import asdict, fields
 from typing import Any, Callable, Dict, List, Set, Tuple
-import asyncio
 import logging
 
 # Third Party
@@ -13,11 +12,17 @@ from tqdm import tqdm
 
 # Local
 from fms_dgt.base.registry import get_resource, register_block
+from fms_dgt.base.telemetry import (
+    payload_max_chars,
+    payload_recording_enabled,
+    record_llm_payload,
+)
 from fms_dgt.core.blocks.llm import (
     LMBlockData,
     LMProvider,
     ToolChoice,
 )
+from fms_dgt.core.blocks.llm.executor import AsyncLLMExecutor
 from fms_dgt.core.resources.watsonx import WatsonXResource
 import fms_dgt.core.blocks.llm.utils as generator_utils
 
@@ -93,6 +98,13 @@ class WatsonXAI(LMProvider):
             model_id=self.model_id_or_path,
             credentials=self._credentials,
             project_id=self._watsonx_resource.project_id,
+        )
+
+        # Register with the credential-based semaphore pool using whichever
+        # credential is configured (token takes precedence over API key).
+        self._init_semaphore(
+            credential=self._watsonx_resource.token or self._watsonx_resource.key,
+            max_concurrent_requests=self._watsonx_resource.max_calls,
         )
 
     # ===========================================================================
@@ -259,40 +271,32 @@ class WatsonXAI(LMProvider):
                 f"Unsupported method ({method}). Please use one of the allowed values: {self.COMPLETION}, {self.CHAT_COMPLETION}."
             )
 
-    async def async_chat_executor(
+    async def _process_chat_item(
         self,
-        queue: asyncio.Queue,
-        update_progress_tracker: Callable,
+        instance: LMBlockData,
+        update_progress: Callable,
     ):
-        """
-        Execute chat completion asynchronously.
-
+        """Process one chat-completion request via the WatsonX AI API.
 
         Args:
-            queue (asyncio.Queue): instances to complete.
-            update_progress_tracker (Callable): progress tracker update function
+            instance: The request to process.
+            update_progress: Zero-argument callable to advance the progress bar.
         """
-        while not queue.empty():
-            # Step 1: Get a "work item" out of the queue.
-            instance = await queue.get()
+        gen_kwargs = self._adjust_chat_completion_parameters(
+            params={**self._chat_parameters, **instance.gen_kwargs}
+        )
 
-            # Step 2: Fetch generation kwargs from 1st request since generation kwargs within a chunk are identical
-            gen_kwargs = instance.gen_kwargs
+        if gen_kwargs.get("logprobs") and gen_kwargs.get("top_logprobs") is None:
+            gen_kwargs["top_logprobs"] = 1
 
-            # Step 3: Extract completion parameters from gen_kwargs
-            gen_kwargs = self._adjust_chat_completion_parameters(
-                params={**self._chat_parameters, **gen_kwargs}
+        async with self._llm_span(
+            method=self.CHAT_COMPLETION, batch_size=1, params=gen_kwargs
+        ) as span_attrs:
+            messages = self._prepare_input(
+                instance, gen_kwargs=gen_kwargs, method=self.CHAT_COMPLETION
             )
-
-            # adding this here to simplify downstream processing
-            if gen_kwargs.get("logprobs") and gen_kwargs.get("top_logprobs") is None:
-                gen_kwargs["top_logprobs"] = 1
-
-            # Step 4: Trigger WatsonX.AI chat completion functions
             response = await self._model.achat(
-                messages=self._prepare_input(
-                    instance, gen_kwargs=gen_kwargs, method=self.CHAT_COMPLETION
-                ),
+                messages=messages,
                 tools=instance.tools,
                 tool_choice=(
                     asdict(instance.tool_choice)
@@ -307,45 +311,48 @@ class WatsonXAI(LMProvider):
                 params=TextChatParameters(**gen_kwargs),
             )
 
-            # Step 5: If multiple choices requested per input
-            # Step 5.a: Get requested choices count from parameters
-            n = gen_kwargs.get("n", 1)
+            span_attrs["prompt_tokens"] = response["usage"]["prompt_tokens"]
+            span_attrs["completion_tokens"] = response["usage"]["completion_tokens"]
 
-            # Step 5.b: Verify enough responses are generated per input
-            if len(response["choices"]) != n:
-                raise RuntimeError(
-                    f"Number of responses ({len(response['choices'])}) does not match number of inputs (1) * n ({n})"
+            if payload_recording_enabled():
+                record_llm_payload(
+                    span_attrs,
+                    self.CHAT_COMPLETION,
+                    payload_max_chars(),
+                    messages=messages,
+                    response_completion=response["choices"][0]["message"],
                 )
 
-            # Step 6: Iterate over each grouped response
-            outputs = []
-            addtl = {
-                "completion_tokens": response["usage"]["completion_tokens"],
-                "prompt_tokens": response["usage"]["prompt_tokens"],
-                "token_logprobs": [],
-            }
-            for choice in response["choices"]:
-                outputs.append(choice["message"])
-
-                token_logprobs = self._extract_token_log_probabilities(
-                    choice=choice, method=self.CHAT_COMPLETION
-                )
-                if token_logprobs:
-                    addtl["token_logprobs"].append(token_logprobs)
-
-            self.update_instance_with_result(
-                self.CHAT_COMPLETION,
-                outputs if len(outputs) > 1 else outputs[0],
-                instance,
-                stop=gen_kwargs.get("stop", None),
-                additional=addtl,
+        n = gen_kwargs.get("n", 1)
+        if len(response["choices"]) != n:
+            raise RuntimeError(
+                f"Number of responses ({len(response['choices'])}) does not match number of inputs (1) * n ({n})"
             )
 
-            # Step 7: Notify the queue that the "work item" has been processed.
-            queue.task_done()
+        outputs = []
+        addtl = {
+            "completion_tokens": response["usage"]["completion_tokens"],
+            "prompt_tokens": response["usage"]["prompt_tokens"],
+            "token_logprobs": [],
+        }
+        for choice in response["choices"]:
+            outputs.append(choice["message"])
 
-            # Step 8: Update progress tracker
-            update_progress_tracker()
+            token_logprobs = self._extract_token_log_probabilities(
+                choice=choice, method=self.CHAT_COMPLETION
+            )
+            if token_logprobs:
+                addtl["token_logprobs"].append(token_logprobs)
+
+        self.update_instance_with_result(
+            self.CHAT_COMPLETION,
+            outputs if len(outputs) > 1 else outputs[0],
+            instance,
+            stop=gen_kwargs.get("stop", None),
+            additional=addtl,
+        )
+
+        update_progress(1)
 
     async def _execute_chat_requests(
         self,
@@ -353,30 +360,14 @@ class WatsonXAI(LMProvider):
         disable_tqdm: bool = False,
         **kwargs,
     ):
-        # Step 1: Initialize necessary variables
-        queue = asyncio.Queue()
-        for request in requests:
-            queue.put_nowait(request)
-
-        # Step 2: Initialize progress tracker
-        pbar = tqdm(
-            total=len(requests),
-            disable=disable_tqdm,
-            desc=f"Running {self.CHAT_COMPLETION} requests",
+        await AsyncLLMExecutor.run(
+            work_items=requests,
+            process_item=self._process_chat_item,
+            call_limit=self._watsonx_resource.max_calls,
+            total_requests=len(requests),
+            method=self.CHAT_COMPLETION,
+            disable_tqdm=disable_tqdm,
         )
-
-        # Step 3: Create generate tasks
-        executors = []
-        for _ in range(min(queue.qsize(), self._watsonx_resource.max_calls)):
-            executors.append(
-                self.async_chat_executor(
-                    queue,
-                    update_progress_tracker=lambda: pbar.update(1),
-                )
-            )
-
-        # Step 4: Wait until all worker are finished
-        await asyncio.gather(*executors, return_exceptions=True)
 
     def completion(self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs) -> None:
         # group requests by their generation_kwargs
@@ -452,6 +443,6 @@ class WatsonXAI(LMProvider):
     def chat_completion(
         self, requests: List[LMBlockData], disable_tqdm: bool = False, **kwargs
     ) -> None:
-        asyncio.run(
+        self.run_async(
             self._execute_chat_requests(requests=requests, disable_tqdm=disable_tqdm, **kwargs)
         )

--- a/fms_dgt/core/datastores/default.py
+++ b/fms_dgt/core/datastores/default.py
@@ -85,7 +85,17 @@ def _is_glob_path(path: str):
 # ===========================================================================
 @register_datastore("default")
 class DefaultDatastore(Datastore):
-    """Base Class for all data stores"""
+    """Local-filesystem-backed datastore.
+
+    All data is stored as files under ``output_dir``.  The store name becomes
+    the file stem (e.g. ``<output_dir>/<store_name>.jsonl``).
+
+    Note: this datastore assumes a local POSIX filesystem.  If you need to
+    write to a remote store (e.g. S3, GCS) implement a new ``Datastore``
+    subclass and register it with ``@register_datastore``.  The ``clear()``,
+    ``save_data()``, ``load_iterators()``, and ``load_data()`` abstracts give
+    you the full surface area you need to support any backend.
+    """
 
     def __init__(
         self,
@@ -111,11 +121,12 @@ class DefaultDatastore(Datastore):
         self._data_split = data_split
         self._buffer_size = buffer_size
         self._data = data or []
-        if self._restart and os.path.exists(self._output_path):
-            os.remove(self._output_path)
 
         if output_dir is not None:
             os.makedirs(output_dir, exist_ok=True)
+
+        if self._restart:
+            self.clear()
 
     # ===========================================================================
     #                       PROPERTIES
@@ -131,6 +142,15 @@ class DefaultDatastore(Datastore):
     # ===========================================================================
     #                       MAIN FUNCTIONS
     # ===========================================================================
+    def exists(self) -> bool:
+        """Return True if the output file for this store exists on disk."""
+        return bool(self._output_path and os.path.exists(self._output_path))
+
+    def clear(self) -> None:
+        """Delete the output file for this store if it exists."""
+        if self._output_path and os.path.exists(self._output_path):
+            os.remove(self._output_path)
+
     def save_data(self, data_to_save: DATASET_TYPE | Iterator) -> None:
 
         output_data_format = os.path.splitext(self._output_path)[-1]

--- a/fms_dgt/core/datastores/multi.py
+++ b/fms_dgt/core/datastores/multi.py
@@ -61,6 +61,15 @@ class MultiTargetDatastore(Datastore):
     # ===========================================================================
     #                       HELPER FUNCTIONS
     # ===========================================================================
+    def exists(self) -> bool:
+        """Return True if the primary backing datastore exists."""
+        return self._primary_datastore.exists()
+
+    def clear(self) -> None:
+        """Clear all backing datastores."""
+        for datastore in self._datastores:
+            datastore.clear()
+
     def save_data(self, *args, **kwargs) -> None:
         """Saves generated data to specified location"""
 

--- a/fms_dgt/generate_data.py
+++ b/fms_dgt/generate_data.py
@@ -19,6 +19,7 @@ from fms_dgt.base.task_card import TaskRunCard
 from fms_dgt.base.telemetry import Span, configure_telemetry
 from fms_dgt.constants import (
     BLOCKS_KEY,
+    DATABUILDER_KEY,
     DGT_ENV_VARS,
     RAY_CONFIG_KEY,
     RUNNER_CONFIG_KEY,
@@ -120,7 +121,7 @@ def generate_data(
             for task_init in utils.read_tasks(task_path):
                 task_init = {
                     **task_init,
-                    **task_overrides.get(task_init["task_name"], dict()),
+                    **task_overrides.get(task_init[TASK_NAME_KEY], dict()),
                 }
                 task_inits.append(task_init)
         else:
@@ -138,7 +139,7 @@ def generate_data(
 
     # Step 7: Collate databuilders from task configurations
     # Step 7.a: Form requested databuilders list
-    requested_databuilder_names = [t["data_builder"] for t in task_inits]
+    requested_databuilder_names = [t[DATABUILDER_KEY] for t in task_inits]
 
     # Step 7.b: Initialize databuilder index
     databuilder_index = DataBuilderIndex(
@@ -191,8 +192,8 @@ def generate_data(
                 {
                     # Step 8.b.i.*: Prepare task card
                     "task_card": TaskRunCard(
-                        task_name=task_init.get("task_name"),
-                        databuilder_name=task_init.get("data_builder"),
+                        task_name=task_init.get(TASK_NAME_KEY),
+                        databuilder_name=task_init.get(DATABUILDER_KEY),
                         task_spec={"task_init": task_init, "task_kwargs": task_kwargs},
                         databuilder_spec=utils.load_nested_paths(builder_cfg, builder_dir),
                         build_id=build_id,
@@ -206,7 +207,7 @@ def generate_data(
                     **{k: v for k, v in task_init.items() if k not in [RUNNER_CONFIG_KEY]},
                 }
                 for task_init in task_inits
-                if task_init["data_builder"] == builder_name
+                if task_init[DATABUILDER_KEY] == builder_name
             ],
             **builder_kwargs,
         }

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -3,6 +3,7 @@
 
 # Standard
 from collections import ChainMap
+from json import JSONDecodeError
 from typing import (
     Any,
     Callable,
@@ -594,7 +595,7 @@ def read_jsonl(file_path: str, encoding: str = "utf-8", lazy: bool = False):
                 if line:
                     try:
                         yield json.loads(line)
-                    except json.JSONDecodeError as err:
+                    except JSONDecodeError as err:
                         dgt_logger.warning("Decoding error %s for line: %s", str(err), line)
 
     if lazy:

--- a/tests/core/blocks/llm/test_llm_anthropic.py
+++ b/tests/core/blocks/llm/test_llm_anthropic.py
@@ -2,12 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 import os
 
 # Third Party
+import anthropic
 import pytest
 
 # Local
+from fms_dgt.base.telemetry import _NoOpSpanWriter
+from fms_dgt.core.blocks.llm import LMBlockData, LMProvider
+from fms_dgt.core.blocks.llm.anthropic import Anthropic
 from tests.core.blocks.llm.test_llm import (
     LM_CFG,
     auto_chat_template_test,
@@ -21,6 +27,63 @@ LM_ANTHROPIC_CFG = {
     "model_id_or_path": "claude-3-haiku-20240307",
     "max_tokens": 25,
 }
+
+
+# ===========================================================================
+#                       HELPERS (unit tests)
+# ===========================================================================
+
+_FAKE_KEY = "sk-ant-test-unit"
+
+
+def _make_provider(**kwargs) -> Anthropic:
+    """Create an Anthropic provider with a mocked client and no-op telemetry."""
+    with patch("fms_dgt.core.blocks.llm.anthropic.get_resource") as mock_res:
+        mock_res.return_value = MagicMock(key=_FAKE_KEY)
+        provider = Anthropic(
+            type="anthropic",
+            name="test-anthropic",
+            model_id_or_path="claude-3-haiku-20240307",
+            **kwargs,
+        )
+    provider._span_writer = _NoOpSpanWriter()
+    provider.async_client = MagicMock()
+    return provider
+
+
+def _text_response(text: str, input_tokens: int = 10, output_tokens: int = 5):
+    """Anthropic message response with a single TextBlock."""
+    content = [anthropic.types.TextBlock(type="text", text=text)]
+    usage = SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+    return SimpleNamespace(content=content, usage=usage, completion=text)
+
+
+def _tool_use_response(
+    tool_name: str, tool_id: str, tool_input: dict, input_tokens: int = 8, output_tokens: int = 3
+):
+    """Anthropic message response with a single ToolUseBlock (no text content)."""
+    content = [
+        anthropic.types.ToolUseBlock(type="tool_use", id=tool_id, name=tool_name, input=tool_input)
+    ]
+    usage = SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+    return SimpleNamespace(content=content, usage=usage)
+
+
+def _mixed_response(
+    text: str,
+    tool_name: str,
+    tool_id: str,
+    tool_input: dict,
+    input_tokens: int = 15,
+    output_tokens: int = 8,
+):
+    """Anthropic message response with both TextBlock and ToolUseBlock."""
+    content = [
+        anthropic.types.TextBlock(type="text", text=text),
+        anthropic.types.ToolUseBlock(type="tool_use", id=tool_id, name=tool_name, input=tool_input),
+    ]
+    usage = SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+    return SimpleNamespace(content=content, usage=usage)
 
 
 @pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"), reason="Anthropic key is not available")
@@ -59,3 +122,93 @@ def test_auto_chat_template(model_cfg):
         exc_info.value.args[0]
         == 'Tokenization support is disabled for "Antropic" provider. Certain capabilites like "apply_chat_template", "truncation" will be unavailable.'
     )
+
+
+# ===========================================================================
+#                       UNIT TESTS (_extract_choice_content)
+# ===========================================================================
+
+
+class TestExtractChoiceContent:
+    def test_text_only_response(self):
+        provider = _make_provider(max_tokens=100)
+        response = _text_response("the answer is 42")
+        result = provider._extract_choice_content(response, method=LMProvider.CHAT_COMPLETION)
+        assert result["role"] == "assistant"
+        assert result["content"] == "the answer is 42"
+        assert "tool_calls" not in result
+
+    def test_tool_use_response_has_tool_calls(self):
+        provider = _make_provider(max_tokens=100)
+        response = _tool_use_response("search", "tc-001", {"query": "test"})
+        result = provider._extract_choice_content(response, method=LMProvider.CHAT_COMPLETION)
+        assert result["role"] == "assistant"
+        assert "content" not in result
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["id"] == "tc-001"
+        assert tc["function"]["name"] == "search"
+        assert tc["function"]["arguments"] == {"query": "test"}
+
+    def test_mixed_response_has_both_content_and_tool_calls(self):
+        provider = _make_provider(max_tokens=100)
+        response = _mixed_response("I will search", "search", "tc-002", {"query": "mixed"})
+        result = provider._extract_choice_content(response, method=LMProvider.CHAT_COMPLETION)
+        assert result["content"] == "I will search"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "search"
+
+    def test_multiple_text_blocks_joined(self):
+        provider = _make_provider(max_tokens=100)
+        content = [
+            anthropic.types.TextBlock(type="text", text="hello"),
+            anthropic.types.TextBlock(type="text", text="world"),
+        ]
+        response = SimpleNamespace(
+            content=content, usage=SimpleNamespace(input_tokens=5, output_tokens=2)
+        )
+        result = provider._extract_choice_content(response, method=LMProvider.CHAT_COMPLETION)
+        assert result["content"] == "hello world"
+
+
+# ===========================================================================
+#                       UNIT TESTS (chat_completion glue)
+# ===========================================================================
+
+
+class TestChatCompletionGlue:
+    def _run_chat(self, provider: Anthropic, instance: LMBlockData, mock_response) -> None:
+        provider.async_client.messages = MagicMock()
+        provider.async_client.messages.create = AsyncMock(return_value=mock_response)
+        provider.chat_completion([instance], disable_tqdm=True)
+
+    def test_result_set_on_instance(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(SRC_DATA={}, input=[{"role": "user", "content": "say hello"}])
+        self._run_chat(provider, instance, _text_response("hello there"))
+        assert instance.result is not None
+
+    def test_token_usage_in_addtl(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(SRC_DATA={}, input=[{"role": "user", "content": "say hello"}])
+        self._run_chat(provider, instance, _text_response("hi", input_tokens=11, output_tokens=6))
+        assert instance.addtl["prompt_tokens"] == 11
+        assert instance.addtl["completion_tokens"] == 6
+
+    def test_tool_call_result_contains_tool_calls(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(
+            SRC_DATA={},
+            input=[{"role": "user", "content": "search for something"}],
+            tools=[{"type": "function", "function": {"name": "search", "parameters": {}}}],
+        )
+        self._run_chat(
+            provider, instance, _tool_use_response("search", "tc-003", {"query": "something"})
+        )
+        assert isinstance(instance.result, dict)
+        assert instance.result["tool_calls"][0]["function"]["name"] == "search"
+
+    def test_completion_method_raises(self):
+        provider = _make_provider(max_tokens=100)
+        with pytest.raises(RuntimeError, match="deprecated"):
+            provider.completion([])

--- a/tests/core/blocks/llm/test_llm_openai.py
+++ b/tests/core/blocks/llm/test_llm_openai.py
@@ -1,0 +1,219 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for OpenAI provider glue code.
+
+These tests mock the OpenAI HTTP client so no real API calls are made.
+They cover:
+- ``_extract_choice_content`` for text and tool-call responses
+- ``_llm_span`` attribute filtering (null n / max_tokens omitted)
+- Token usage propagated from response to ``LMBlockData.addtl``
+- Result written to ``LMBlockData.result`` after a completion call
+"""
+
+# Standard
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Local
+from fms_dgt.base.telemetry import _NoOpSpanWriter
+from fms_dgt.core.blocks.llm import LMBlockData, LMProvider
+from fms_dgt.core.blocks.llm.openai import OpenAI
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_KEY = "sk-test-openai-unit"
+
+
+def _make_provider(**kwargs) -> OpenAI:
+    """Create an OpenAI provider with a mocked async client and no-op telemetry."""
+    with patch("fms_dgt.core.blocks.llm.openai.get_resource") as mock_res:
+        mock_res.return_value = MagicMock(key=_FAKE_KEY)
+        provider = OpenAI(
+            type="openai",
+            name="test-openai",
+            model_id_or_path="gpt-4o",
+            **kwargs,
+        )
+    provider._span_writer = _NoOpSpanWriter()
+    provider.async_client = MagicMock()
+    return provider
+
+
+def _text_choice(text: str, prompt_tokens: int = 10, completion_tokens: int = 5):
+    """Build a minimal OpenAI completion response with one text choice."""
+    choice = SimpleNamespace(text=text, logprobs=None)
+    usage = SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _chat_message_mock(to_dict_value: dict):
+    """Return a MagicMock that looks like a ChatCompletionMessage to isinstance."""
+    # Third Party
+    import openai.types.chat.chat_completion_message as _mod
+
+    msg = MagicMock(spec=_mod.ChatCompletionMessage)
+    msg.to_dict.return_value = to_dict_value
+    return msg
+
+
+def _chat_text_choice(content: str, prompt_tokens: int = 10, completion_tokens: int = 5):
+    """Build a minimal chat completion response with plain text content."""
+    msg = _chat_message_mock({"role": "assistant", "content": content})
+    choice = SimpleNamespace(message=msg, logprobs=None)
+    usage = SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _chat_tool_call_choice(
+    tool_name: str, arguments: str, prompt_tokens: int = 8, completion_tokens: int = 3
+):
+    """Build a chat completion response that contains a tool call (content=None)."""
+    msg = _chat_message_mock(
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "tc-001",
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": arguments},
+                }
+            ],
+        }
+    )
+    choice = SimpleNamespace(message=msg, logprobs=None)
+    usage = SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+# ---------------------------------------------------------------------------
+# _extract_choice_content
+# ---------------------------------------------------------------------------
+
+
+class TestExtractChoiceContent:
+    def test_completion_returns_text(self):
+        provider = _make_provider()
+        choice = SimpleNamespace(text="hello world", logprobs=None)
+        result = provider._extract_choice_content(choice, method=LMProvider.COMPLETION)
+        assert result == "hello world"
+
+    def test_chat_text_returns_dict(self):
+        provider = _make_provider()
+        response = _chat_text_choice("the answer is 42")
+        result = provider._extract_choice_content(
+            response.choices[0], method=LMProvider.CHAT_COMPLETION
+        )
+        assert isinstance(result, dict)
+        assert result["role"] == "assistant"
+        assert result["content"] == "the answer is 42"
+
+    def test_chat_tool_call_returns_dict_with_tool_calls(self):
+        provider = _make_provider()
+        response = _chat_tool_call_choice("search", '{"query": "test"}')
+        result = provider._extract_choice_content(
+            response.choices[0], method=LMProvider.CHAT_COMPLETION
+        )
+        assert isinstance(result, dict)
+        assert result["content"] is None
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "search"
+
+
+# ---------------------------------------------------------------------------
+# _llm_span: null attribute filtering
+# ---------------------------------------------------------------------------
+
+
+class TestLlmSpanNullFiltering:
+    """Verify that span attrs omit n / max_tokens when not set in params."""
+
+    def _run_span(self, provider: OpenAI, params: dict) -> dict:
+        """Run _llm_span and capture the attrs dict it yields."""
+        captured = {}
+
+        async def _inner():
+            async with provider._llm_span("completion", batch_size=1, params=params) as attrs:
+                captured.update(attrs)
+
+        provider.run_async(_inner())
+        return captured
+
+    def test_no_null_n_when_not_set(self):
+        provider = _make_provider()
+        attrs = self._run_span(provider, {"temperature": 0.7})
+        assert "n" not in attrs
+
+    def test_no_null_max_tokens_when_not_set(self):
+        provider = _make_provider()
+        attrs = self._run_span(provider, {"temperature": 0.7})
+        assert "max_tokens" not in attrs
+
+    def test_n_present_when_set(self):
+        provider = _make_provider()
+        attrs = self._run_span(provider, {"n": 3})
+        assert attrs["n"] == 3
+
+    def test_max_tokens_resolved_from_max_completion_tokens(self):
+        provider = _make_provider()
+        attrs = self._run_span(provider, {"max_completion_tokens": 256})
+        assert attrs["max_tokens"] == 256
+
+    def test_temperature_present_when_set(self):
+        provider = _make_provider()
+        attrs = self._run_span(provider, {"temperature": 0.5})
+        assert attrs["temperature"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# chat_completion: result + token usage propagation
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionGlue:
+    """End-to-end through _process_item using a mocked async client."""
+
+    def _run_chat(self, provider: OpenAI, instance: LMBlockData, mock_response) -> None:
+        provider.async_client.chat = MagicMock()
+        provider.async_client.chat.completions = MagicMock()
+        provider.async_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        provider.chat_completion([instance], disable_tqdm=True)
+
+    def test_result_set_on_instance(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(
+            SRC_DATA={},
+            input=[{"role": "user", "content": "say hello"}],
+        )
+        response = _chat_text_choice("hello there", prompt_tokens=10, completion_tokens=4)
+        self._run_chat(provider, instance, response)
+        assert instance.result is not None
+        assert isinstance(instance.result, (str, dict))
+
+    def test_token_usage_in_addtl(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(
+            SRC_DATA={},
+            input=[{"role": "user", "content": "say hello"}],
+        )
+        response = _chat_text_choice("hello", prompt_tokens=12, completion_tokens=7)
+        self._run_chat(provider, instance, response)
+        assert instance.addtl is not None
+        assert instance.addtl["prompt_tokens"] == 12
+        assert instance.addtl["completion_tokens"] == 7
+
+    def test_tool_call_result_contains_tool_calls(self):
+        provider = _make_provider(max_tokens=100)
+        instance = LMBlockData(
+            SRC_DATA={},
+            input=[{"role": "user", "content": "search for something"}],
+            tools=[{"type": "function", "function": {"name": "search", "parameters": {}}}],
+        )
+        response = _chat_tool_call_choice("search", '{"query": "something"}')
+        self._run_chat(provider, instance, response)
+        result = instance.result
+        assert isinstance(result, dict)
+        assert "tool_calls" in result
+        assert result["tool_calls"][0]["function"]["name"] == "search"

--- a/tests/core/blocks/llm/test_utils.py
+++ b/tests/core/blocks/llm/test_utils.py
@@ -1,0 +1,194 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for fms_dgt.core.blocks.llm.utils.
+
+Covers:
+- ``retry`` decorator: sync and async paths, exponential backoff, Retry-After
+  header honoured, eventual success after transient failures.
+- ``_retry_after_seconds``: header present, header absent, no .response attr.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+import asyncio
+
+# Local
+from fms_dgt.core.blocks.llm.utils import _retry_after_seconds, retry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeError(Exception):
+    """Simulates an SDK error that may carry a Retry-After header."""
+
+    def __init__(self, message="rate limited", retry_after: float | None = None):
+        super().__init__(message)
+        if retry_after is not None:
+            self.response = MagicMock()
+            self.response.headers = MagicMock()
+            self.response.headers.get = lambda key, default=None: (
+                str(retry_after) if key == "retry-after" else default
+            )
+        # no .response attribute when retry_after is None — matches exceptions
+        # that do not carry an HTTP response (e.g. connection errors)
+
+
+# ---------------------------------------------------------------------------
+# _retry_after_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_seconds_uses_header_when_present():
+    exc = _FakeError(retry_after=42.0)
+    assert _retry_after_seconds(exc, backoff_time=10.0) == 42.0
+
+
+def test_retry_after_seconds_falls_back_to_backoff_when_no_response():
+    exc = _FakeError()  # no .response attribute
+    assert _retry_after_seconds(exc, backoff_time=7.5) == 7.5
+
+
+def test_retry_after_seconds_falls_back_when_header_missing():
+    exc = _FakeError()
+    exc.response = MagicMock()
+    exc.response.headers = MagicMock()
+    exc.response.headers.get = lambda key, default=None: default
+    assert _retry_after_seconds(exc, backoff_time=5.0) == 5.0
+
+
+# ---------------------------------------------------------------------------
+# retry — sync path
+# ---------------------------------------------------------------------------
+
+
+def test_retry_sync_succeeds_immediately():
+    call_count = 0
+
+    @retry(on_exceptions=(_FakeError,), max_retries=3, backoff_time=0.0)
+    def fn():
+        nonlocal call_count
+        call_count += 1
+        return "ok"
+
+    with patch("fms_dgt.core.blocks.llm.utils.time.sleep"):
+        result = fn()
+
+    assert result == "ok"
+    assert call_count == 1
+
+
+def test_retry_sync_retries_on_exception_then_succeeds():
+    attempts = []
+
+    @retry(on_exceptions=(_FakeError,), max_retries=3, backoff_time=0.0)
+    def fn():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise _FakeError()
+        return "done"
+
+    with patch("fms_dgt.core.blocks.llm.utils.time.sleep"):
+        result = fn()
+
+    assert result == "done"
+    assert len(attempts) == 3
+
+
+def test_retry_sync_exhausts_retries_silently():
+    """After max_retries failures the wrapper returns None (no re-raise)."""
+
+    @retry(on_exceptions=(_FakeError,), max_retries=2, backoff_time=0.0)
+    def fn():
+        raise _FakeError()
+
+    with patch("fms_dgt.core.blocks.llm.utils.time.sleep"):
+        result = fn()
+
+    assert result is None
+
+
+def test_retry_sync_uses_retry_after_header():
+    """sync wrapper must pass the Retry-After value to time.sleep."""
+
+    @retry(on_exceptions=(_FakeError,), max_retries=2, backoff_time=99.0)
+    def fn():
+        raise _FakeError(retry_after=1.5)
+
+    with patch("fms_dgt.core.blocks.llm.utils.time.sleep") as mock_sleep:
+        fn()
+
+    for call in mock_sleep.call_args_list:
+        assert call.args[0] == 1.5
+
+
+# ---------------------------------------------------------------------------
+# retry — async path
+# ---------------------------------------------------------------------------
+
+
+def test_retry_async_succeeds_immediately():
+    call_count = 0
+
+    @retry(on_exceptions=(_FakeError,), max_retries=3, backoff_time=0.0)
+    async def fn():
+        nonlocal call_count
+        call_count += 1
+        return "ok"
+
+    with patch("fms_dgt.core.blocks.llm.utils.asyncio.sleep", new_callable=AsyncMock):
+        result = asyncio.run(fn())
+
+    assert result == "ok"
+    assert call_count == 1
+
+
+def test_retry_async_retries_on_exception_then_succeeds():
+    attempts = []
+
+    @retry(on_exceptions=(_FakeError,), max_retries=3, backoff_time=0.0)
+    async def fn():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise _FakeError()
+        return "done"
+
+    with patch("fms_dgt.core.blocks.llm.utils.asyncio.sleep", new_callable=AsyncMock):
+        result = asyncio.run(fn())
+
+    assert result == "done"
+    assert len(attempts) == 3
+
+
+def test_retry_async_uses_asyncio_sleep_not_time_sleep():
+    """The async wrapper must call asyncio.sleep, never time.sleep."""
+
+    @retry(on_exceptions=(_FakeError,), max_retries=2, backoff_time=0.0)
+    async def fn():
+        raise _FakeError()
+
+    with (
+        patch(
+            "fms_dgt.core.blocks.llm.utils.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_async_sleep,
+        patch("fms_dgt.core.blocks.llm.utils.time.sleep") as mock_time_sleep,
+    ):
+        asyncio.run(fn())
+
+    assert mock_async_sleep.call_count > 0
+    mock_time_sleep.assert_not_called()
+
+
+def test_retry_async_uses_retry_after_header():
+    """async wrapper must pass the Retry-After value to asyncio.sleep."""
+
+    @retry(on_exceptions=(_FakeError,), max_retries=2, backoff_time=99.0)
+    async def fn():
+        raise _FakeError(retry_after=2.5)
+
+    with patch("fms_dgt.core.blocks.llm.utils.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        asyncio.run(fn())
+
+    for call in mock_sleep.call_args_list:
+        assert call.args[0] == 2.5

--- a/tests/core/blocks/utilities/test_field_map.py
+++ b/tests/core/blocks/utilities/test_field_map.py
@@ -4,6 +4,7 @@
 # Standard
 from dataclasses import dataclass
 from typing import Any
+import asyncio
 
 # Local
 from fms_dgt.core.blocks.utilities.field_map import FieldMapBlock
@@ -54,3 +55,58 @@ def test_field_map_dict():
         and test_data[0]["field3"] == 2
         and test_data[0]["field4"] == 3
     )
+
+
+# ===========================================================================
+#                       acall / aexecute
+# ===========================================================================
+
+
+def test_acall_produces_same_result_as_call():
+    """acall should produce the same output as __call__ for a sync block."""
+    block = FieldMapBlock(
+        name="test_async_field_map",
+        field_map={"field1": "field2"},
+    )
+    test_data = [{"field1": 1, "field2": 2, "field3": 3}]
+    expected = block([{"field1": 1, "field2": 2, "field3": 3}])
+
+    # Reset: FieldMapBlock mutates in-place, so use a fresh copy
+    test_data = [{"field1": 1, "field2": 2, "field3": 3}]
+    result = asyncio.run(block.acall(test_data))
+
+    assert list(result)[0]["field2"] == list(expected)[0]["field2"]
+
+
+def test_acall_returns_list_when_input_is_list():
+    block = FieldMapBlock(
+        name="test_async_list",
+        field_map={"field1": "field2"},
+    )
+    test_data = [{"field1": 10, "field2": 20}]
+    result = asyncio.run(block.acall(test_data))
+    assert isinstance(result, list)
+
+
+def test_acall_multiple_items():
+    block = FieldMapBlock(
+        name="test_async_multi",
+        field_map={"field1": "field2"},
+    )
+    test_data = [{"field1": i, "field2": 0, "field3": i * 2} for i in range(5)]
+    result = asyncio.run(block.acall(test_data))
+    outputs = list(result)
+    assert len(outputs) == 5
+    for i, out in enumerate(outputs):
+        assert out["field2"] == i  # field2 now holds original field1 value
+
+
+def test_aexecute_is_coroutine():
+    # Standard
+    import inspect
+
+    block = FieldMapBlock(name="test_coro_check", field_map={"field1": "field2"})
+    # aexecute returns a coroutine when called
+    coro = block.aexecute([{"field1": 1, "field2": 2}])
+    assert inspect.iscoroutine(coro)
+    coro.close()  # clean up without running

--- a/tests/core/datastores/test_default.py
+++ b/tests/core/datastores/test_default.py
@@ -1,6 +1,9 @@
 # Copyright The DiGiT Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+import os
+
 # Third Party
 from dotenv import load_dotenv
 
@@ -234,3 +237,51 @@ class TestDefault:
 
         items = datastore.load_data()
         assert len(items) == 3
+
+
+class TestDefaultExistsClear:
+    """Tests for DefaultDatastore.exists() and clear()."""
+
+    def _ds(self, tmp_path, **kwargs):
+        """Helper: create a DefaultDatastore whose output goes to tmp_path."""
+        return DefaultDatastore(
+            type="default",
+            store_name="data",
+            output_dir=str(tmp_path),
+            **kwargs,
+        )
+
+    def test_exists_false_when_no_output_dir(self):
+        ds = DefaultDatastore(type="default", store_name="test")
+        assert ds.exists() is False
+
+    def test_exists_false_before_any_write(self, tmp_path):
+        ds = self._ds(tmp_path)
+        assert ds.exists() is False
+
+    def test_exists_true_after_write(self, tmp_path):
+        ds = self._ds(tmp_path)
+        ds.save_data([{"key": "value"}])
+        assert ds.exists() is True
+
+    def test_clear_removes_output_file(self, tmp_path):
+        ds = self._ds(tmp_path)
+        ds.save_data([{"key": "value"}])
+        assert os.path.exists(ds.output_path)
+        ds.clear()
+        assert not os.path.exists(ds.output_path)
+
+    def test_clear_is_idempotent(self, tmp_path):
+        ds = self._ds(tmp_path)
+        ds.clear()  # file never existed — must not raise
+        ds.clear()  # second call also must not raise
+
+    def test_restart_clears_existing_file(self, tmp_path):
+        # First run: write some data
+        ds = self._ds(tmp_path)
+        ds.save_data([{"key": "first_run"}])
+        output = ds.output_path
+        assert os.path.exists(output)
+        # Second run with restart=True: file should be cleared on init
+        self._ds(tmp_path, restart=True)
+        assert not os.path.exists(output)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it

 ### Phase 1: 
* Replace one-shot asyncio.run() with a persistent per-provider event loop and daemon thread (run_async)
* Add AsyncLLMExecutor queue-and-worker scaffolding shared across all providers
* Add CredentialPool (_DualSemaphore) for per-API-key concurrency limits with sync and async interfaces
* Migrate OpenAI, Anthropic, WatsonX, and Ollama to async _process_item + _execute_requests
* Fix Ollama to use AsyncClient for true concurrent requests

### Phase 2: 
* _llm_span async context manager on LMProvider emits dgt.llm_call spans with token usage, semaphore wait time, temperature/n/max_tokens (omitted when null)
* Centralise payload recording into record_llm_payload() helper in telemetry.py; rename _payload_recording_enabled/_payload_max_chars to public names
* Fix tool-call responses silently dropping tool_calls from spans

### Phase 3: 
* Add acall()/aexecute() to Block base class (default asyncio.to_thread)
* ValidatorBlock and LMProvider inherit with no override needed. 

### Other fixes:
  - async_wrapper in retry() was calling time.sleep(), blocking the event loop on every retry; fixed to await asyncio.sleep()
  - Add _retry_after_seconds() to honour Retry-After header on HTTP 429 responses (both OpenAI and Anthropic set this via httpx.Response) in sync and async paths
  - Move restart_generation from TaskRunnerConfig to GenerationTaskRunnerConfig; add --restart CLI alias; introduce Task._post_init() pattern so subclasses set their own state before datastore init runs
  - Add exists()/clear() abstracts to Datastore; implement in DefaultDatastore and MultiTargetDatastore; clear stale postproc_data_N files on restart via exists() probe loop so cleanup works for any backend
  - Fix AttributeError on interpreter shutdown in lazy JSONL generator: bind JSONDecodeError by name at import time instead of dotted json.JSONDecodeError

### Tests: 

provider unit tests with mocked HTTP clients (OpenAI _extract_choice_content, _llm_span null filtering, chat glue; Anthropic text/tool-use/mixed responses, chat glue); retry unit tests (asyncio.sleep regression guard, Retry-After header); acall/aexecute via FieldMapBlock; record_llm_payload and payload helpers; DefaultDatastore exists()/clear()/restart.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
