### PR TITLE
refactor(concurrent): flat per-task state machine + RAG stage refinements 

### DIFF
--- a/fms_dgt/base/databuilder/base.py
+++ b/fms_dgt/base/databuilder/base.py
@@ -465,11 +465,13 @@ class DataBuilder:
             self._unregister_task_log_handler(task)
             task.close_log_handler()
 
-    def execute_postprocessing(self, completed_tasks: List[Task]):
+    def execute_postprocessing(self, completed_tasks: List[Task], task_epoch: int = None):
         """Executes any postprocessing required after tasks have completed.
 
         Args:
             completed_tasks (List[SdgTask]): tasks that have been completed and can undergo postprocessing
+            task_epoch: epoch counter for the tasks being postprocessed, used for logging.
+                Defaults to self._epoch when not provided.
         """
         if self._config.postprocessors:
             # TODO: This could potentially be very expensive,
@@ -502,9 +504,13 @@ class DataBuilder:
                 post_processed_data.extend(data)
 
             # write results
-            self._write_postprocessing(completed_tasks, post_processed_data)
+            self._write_postprocessing(completed_tasks, post_processed_data, task_epoch=task_epoch)
 
-    def _write_postprocessing(self, completed_tasks: List[Task], data: DATASET_TYPE):
+    def _write_postprocessing(
+        self, completed_tasks: List[Task], data: DATASET_TYPE, task_epoch: int = None
+    ):
+        epoch = task_epoch if task_epoch is not None else self._epoch
+
         # write outputs to datastore
         for task in completed_tasks:
             # update pointer to current datastore
@@ -524,7 +530,7 @@ class DataBuilder:
             tasks[task_name][1] += 1
 
         self.logger.info("*" * 99)
-        self.logger.info("\t[EPOCH %d]\tPOST-PROCESSING RESULTS", self._epoch)
+        self.logger.info("\t[EPOCH %d]\tPOST-PROCESSING RESULTS", epoch)
         self.logger.info("*" * 99)
         self.logger.info(
             "Task%s\tBefore\t\t\tAfter",

--- a/fms_dgt/base/databuilder/concurrent.py
+++ b/fms_dgt/base/databuilder/concurrent.py
@@ -33,30 +33,31 @@ class ConcurrentGenerationDataBuilderConfig(DataBuilderConfig):
 class ConcurrentGenerationDataBuilder(GenerationDataBuilder):
     """A GenerationDataBuilder that runs work items concurrently via a thread pool.
 
-    Replaces the synchronous inner loop of GenerationDataBuilder.execute_tasks()
-    with a ThreadPoolExecutor that processes mini-batches of data points in
-    parallel. Mirrors the full epoch loop of GenerationDataBuilder including the
-    outer loop that re-queues tasks after postprocessing if their data count
-    dropped below num_outputs_to_generate.
+    Each task owns its full lifecycle independently. Generation and postprocessing
+    both run as futures in a shared ThreadPoolExecutor. The main thread only makes
+    routing decisions; it never blocks on task work.
 
-    Worker allocation across tasks uses a proportional-fill policy:
-    - Every incomplete task is guaranteed at least 1 worker slot.
-    - Remaining slots are distributed proportionally by each task's remaining
-      work (num_outputs_to_generate - produced so far).
-    - If a task has fewer items remaining than its allocated slots, it only
-      spawns as many futures as it has work for; freed slots flow to other
-      tasks on the next recompute.
-    - Allocation is recomputed on every future completion.
-    - Unused slots after proportional distribution are redistributed to tasks
-      with the most remaining work, ensuring full pool utilization.
+    Per-task lifecycle (state machine):
 
-    Two levels of stall detection mirror GenerationDataBuilder:
-    - Per-future stall: incremented each time a future returns zero successes;
+        GENERATING ──(is_complete or gen_stalled)──→ DRAINING
+        DRAINING   ──(in_flight == 0)─────────────→ PENDING_POSTPROC
+        PENDING_POSTPROC ──(worker available)──────→ IN_POSTPROC
+        IN_POSTPROC ──(future resolves, done)──────→ task.finish()
+                    ──(future resolves, re-queue)──→ GENERATING
+
+    Worker allocation (priority-based, recomputed on every future completion):
+    - Step 1: Tasks in PENDING_POSTPROC each consume one slot (highest priority).
+      A task one step from finish() is served before generation gets anything.
+    - Step 2: Remaining slots are distributed to GENERATING tasks using
+      proportional fill with a per-task floor of 1.
+
+    Two levels of stall detection:
+    - Per-future stall: incremented each time a gen future returns zero successes;
       reset on any success. Task exits generation when counter reaches
       max_stalled_attempts.
     - Per-epoch stall: incremented each time postprocessing leaves a task with
       zero data; reset when postprocessing retains any data. Task is terminated
-      when this counter reaches max_stalled_attempts (stalled_postprocessing).
+      when this counter reaches max_stalled_attempts.
 
     The __call__ contract for subclasses:
     - Take N inputs, return M outputs (M <= N).
@@ -109,6 +110,7 @@ class ConcurrentGenerationDataBuilder(GenerationDataBuilder):
         self,
         active_tasks: List[GenerationTask],
         in_flight_per_task: Dict[str, int],
+        available_slots: int,
     ) -> Dict[str, int]:
         """Compute how many additional workers to spawn per task.
 
@@ -122,13 +124,12 @@ class ConcurrentGenerationDataBuilder(GenerationDataBuilder):
         Args:
             active_tasks: Tasks that still need work.
             in_flight_per_task: Count of currently running futures per task.
+            available_slots: Worker slots available for generation (caller has
+                already reserved slots for postprocessing tasks).
 
         Returns:
             Dict mapping task name to number of new futures to spawn.
         """
-        total_in_flight = sum(in_flight_per_task.values())
-        available_slots = self._max_workers - total_in_flight
-
         if available_slots <= 0 or not active_tasks:
             return {}
 
@@ -203,24 +204,21 @@ class ConcurrentGenerationDataBuilder(GenerationDataBuilder):
     #                       EXECUTE TASKS
     # ===========================================================================
     def execute_tasks(self):
-        """Concurrent execution loop.
+        """Flat event loop — each task progresses through its lifecycle independently.
 
-        Mirrors GenerationDataBuilder.execute_tasks() with a two-level loop:
+        State sets (per-task name strings):
+            generating       — tasks currently submitting gen futures
+            draining         — gen exit signalled, waiting for in-flight gen futures to land
+            pending_postproc — all gen futures drained, waiting for a postproc worker slot
+            in_postproc      — postproc future in flight
 
-        Outer loop (epochs): runs while any task is still incomplete and the
-        attempt budget has not been exhausted. After each epoch's generation
-        phase, postprocessing runs on all tasks that produced data. Tasks that
-        are still incomplete after postprocessing re-enter the next epoch's
-        generation phase. A per-epoch stall counter terminates tasks where
-        postprocessing consistently destroys all data.
+        futures maps each Future to (task_name, "gen"|"postproc").
 
-        Inner loop (generation phase): a ThreadPoolExecutor drains all active
-        tasks concurrently. Workers are allocated proportionally with a
-        per-task floor of 1. Allocation is recomputed on every future
-        completion. A per-future stall counter terminates tasks that
-        consistently produce zero results.
+        Span hierarchy emitted per task:
+            dgt.task            — full task lifetime
+              dgt.epoch         — one generation round (first future → last future lands)
+              dgt.postprocessing — one postprocessing run
         """
-
         # Load existing machine data and dataloader state.
         for task in self._tasks:
             task.machine_data = task.load_intermediate_data()
@@ -260,248 +258,330 @@ class ConcurrentGenerationDataBuilder(GenerationDataBuilder):
 
         start_time = time.time()
 
-        # Per-future stall counters: incremented when a future returns zero
-        # successes; reset on any success.
-        consecutive_empty_futures: Dict[str, int] = {t.name: 0 for t in active_tasks}
+        task_by_name: Dict[str, GenerationTask] = {t.name: t for t in active_tasks}
 
-        # Per-epoch stall counters: incremented when postprocessing leaves a
-        # task with zero data; reset when postprocessing retains any data.
-        consecutive_empty_epochs: Dict[str, int] = {t.name: 0 for t in active_tasks}
+        # Per-task epoch counters (for logging and postproc).
+        task_epoch: Dict[str, int] = {t.name: 1 for t in active_tasks}
 
+        # Per-future stall counters: incremented when a gen future returns zero
+        # successes; reset on any success. Reset to 0 on re-queue into generating.
+        empty_futures: Dict[str, int] = {t.name: 0 for t in active_tasks}
+
+        # Per-epoch stall counters: incremented when postprocessing leaves a task
+        # with zero data. Accumulates across re-queues (persistent signal).
+        empty_epochs: Dict[str, int] = {t.name: 0 for t in active_tasks}
+
+        # In-flight future counts (gen + postproc combined per task).
+        in_flight: Dict[str, int] = {t.name: 0 for t in active_tasks}
+
+        # Per-task, per-epoch attempt counters. Incremented each time a gen
+        # future is submitted; attached to the dgt.epoch span at close time
+        # and reset when the task re-enters generation.
+        epoch_attempts: Dict[str, int] = {t.name: 0 for t in active_tasks}
+
+        # Lifecycle state sets (hold task name strings).
+        generating: set = {t.name for t in active_tasks}
+        draining: set = set()  # gen exit signalled, outstanding gen futures remain
+        pending_postproc: set = set()
+        in_postproc: set = set()
+
+        # futures[fut] = (task_name, "gen"|"postproc")
+        futures: Dict[Future, Any] = {}
+
+        # Global attempt counter: incremented on every completed gen future across
+        # all tasks and epochs. Used solely to enforce _num_attempts_to_complete,
+        # the absolute cap on total generation work for the entire run.
         attempt = 0
 
-        # Outer epoch loop: re-enters when tasks remain incomplete after
-        # postprocessing and the attempt budget has not been exhausted.
-        while active_tasks and attempt <= self._num_attempts_to_complete:
-
-            with Span(
-                "dgt.epoch",
+        # Open one dgt.task span per active task. Closed just before task.finish().
+        # build_id/run_id are auto-injected from the active run_context ContextVar
+        # in Span.__exit__ — no need to pass them explicitly here.
+        task_spans: Dict[str, Span] = {}
+        for task in active_tasks:
+            span = Span(
+                "dgt.task",
                 self._span_writer,
                 parent_span_name="dgt.run",
-                epoch=self._epoch,
-                active_task_names=",".join(t.name for t in active_tasks),
-                active_task_count=len(active_tasks),
-            ):
-                self.logger.info("*" * 99)
-                self.logger.info("\t\t\t\tCONCURRENT GENERATION — EPOCH %s", self._epoch)
-                self.logger.info("*" * 99)
-                self.logger.info(
-                    "Epoch %s started: %s worker(s), %s active task(s): %s",
-                    self._epoch,
-                    self._max_workers,
-                    len(active_tasks),
-                    ", ".join(t.name for t in active_tasks),
-                    extra={
-                        "event": "epoch_started",
-                        "epoch": self._epoch,
-                        "active_task_names": [t.name for t in active_tasks],
-                        "active_task_count": len(active_tasks),
-                        "max_workers": self._max_workers,
-                    },
-                )
+                task_name=task.name,
+            )
+            span.__enter__()
+            task_spans[task.name] = span
 
-                # ---------------------------------------------------------------
-                # Generation phase: run thread pool until all active tasks are
-                # either complete or stalled.
-                # ---------------------------------------------------------------
-                tasks_in_generation: List[GenerationTask] = list(active_tasks)
-                tasks_finished_generation: List[GenerationTask] = []
+        # Open epoch and postproc spans are tracked here; populated by
+        # _allocate_and_spawn and closed in the event loop.
+        epoch_spans: Dict[str, Span] = {}
+        postproc_spans: Dict[str, Span] = {}
 
-                futures: Dict[Future, str] = {}
-                in_flight_per_task: Dict[str, int] = {t.name: 0 for t in tasks_in_generation}
+        executor = ThreadPoolExecutor(max_workers=self._max_workers)
+        try:
+            self._allocate_and_spawn(
+                task_by_name,
+                futures,
+                task_epoch,
+                in_flight,
+                generating,
+                pending_postproc,
+                in_postproc,
+                executor,
+                epoch_spans,
+                postproc_spans,
+                epoch_attempts,
+            )
 
-                executor = ThreadPoolExecutor(max_workers=self._max_workers)
-                try:
-                    self._spawn_futures(tasks_in_generation, futures, in_flight_per_task, executor)
+            while futures:
+                done, _ = wait(futures, return_when=FIRST_COMPLETED)
 
-                    while futures:
+                for fut in done:
+                    task_name, future_type = futures.pop(fut)
+                    in_flight[task_name] -= 1
+                    task = task_by_name[task_name]
+
+                    # ----------------------------------------------------------
+                    # Generation future completed.
+                    # ----------------------------------------------------------
+                    if future_type == "gen":
                         attempt += 1
-                        done, _ = wait(futures, return_when=FIRST_COMPLETED)
+                        results: List[DataPoint] = fut.result()
+                        successes = 0
 
-                        for fut in done:
-                            task_name = futures.pop(fut)
-                            if task_name in in_flight_per_task:
-                                in_flight_per_task[task_name] -= 1
+                        with self._task_locks[task_name]:
+                            for dp in results:
+                                task.save_intermediate_data(dp)
+                                task.save_dataloader_state()
+                                task.machine_data.append(dp)
+                                successes += 1
 
-                            task = next(t for t in self._tasks if t.name == task_name)
-                            results: List[DataPoint] = fut.result()
-                            successes = 0
+                        if successes > 0:
+                            empty_futures[task_name] = 0
+                        else:
+                            empty_futures[task_name] += 1
 
-                            with self._task_locks[task_name]:
-                                for dp in results:
-                                    task.save_intermediate_data(dp)
-                                    task.save_dataloader_state()
-                                    task.machine_data.append(dp)
-                                    successes += 1
+                        gen_stalled = empty_futures[task_name] >= self._max_stalled_attempts
+                        budget_exhausted = attempt > self._num_attempts_to_complete
 
-                            # Per-future stall detection.
-                            if successes > 0:
-                                consecutive_empty_futures[task_name] = 0
+                        # Decide whether this task should exit generation.
+                        should_exit_gen = task_name in generating and (
+                            task.is_complete() or gen_stalled or budget_exhausted
+                        )
+
+                        if should_exit_gen:
+                            if gen_stalled and not task.is_complete():
+                                self.logger.warning(
+                                    "Task %s has not generated any data in the last %s futures, moving to postprocessing",
+                                    task_name,
+                                    self._max_stalled_attempts,
+                                )
+                            generating.discard(task_name)
+                            if in_flight[task_name] == 0:
+                                # Close epoch span: no more gen futures for this epoch.
+                                if task_name in epoch_spans:
+                                    span = epoch_spans.pop(task_name)
+                                    span.num_attempts = epoch_attempts[task_name]
+                                    span.__exit__(None, None, None)
+                                pending_postproc.add(task_name)
                             else:
-                                consecutive_empty_futures[task_name] += 1
+                                draining.add(task_name)
 
-                            stalled = (
-                                consecutive_empty_futures[task_name] >= self._max_stalled_attempts
+                        elif task_name in draining and in_flight[task_name] == 0:
+                            # Last in-flight gen future for a draining task landed.
+                            draining.discard(task_name)
+                            # Close epoch span: generation round fully drained.
+                            if task_name in epoch_spans:
+                                span = epoch_spans.pop(task_name)
+                                span.num_attempts = epoch_attempts[task_name]
+                                span.__exit__(None, None, None)
+                            pending_postproc.add(task_name)
+
+                    # ----------------------------------------------------------
+                    # Postprocessing future completed.
+                    # ----------------------------------------------------------
+                    else:
+                        in_postproc.discard(task_name)
+                        epoch = task_epoch[task_name]
+
+                        # Close postproc span.
+                        if task_name in postproc_spans:
+                            postproc_spans.pop(task_name).__exit__(None, None, None)
+
+                        if task.machine_data:
+                            empty_epochs[task_name] = 0
+                        else:
+                            empty_epochs[task_name] += 1
+
+                        epoch_stalled = empty_epochs[task_name] >= self._max_stalled_attempts
+                        gen_stalled = empty_futures[task_name] >= self._max_stalled_attempts
+
+                        if task.is_complete() or gen_stalled or epoch_stalled:
+                            if epoch_stalled and not task.is_complete():
+                                self.logger.warning(
+                                    "Task %s has not produced any data after postprocessing in the last %s epochs, terminating",
+                                    task_name,
+                                    self._max_stalled_attempts,
+                                )
+                            reason = (
+                                "complete"
+                                if task.is_complete()
+                                else (
+                                    "stalled_generation"
+                                    if gen_stalled
+                                    else "stalled_postprocessing"
+                                )
+                            )
+                            self.logger.info(
+                                "Task '%s' finished.",
+                                task_name,
+                                extra={
+                                    "event": "task_finished",
+                                    "task_name": task_name,
+                                    "reason": reason,
+                                    "epoch": epoch,
+                                    "produced": len(task.machine_data),
+                                },
+                            )
+                            # Close task span before finish().
+                            if task_name in task_spans:
+                                task_spans.pop(task_name).__exit__(None, None, None)
+                            task.finish()
+                            # Remove from all tracking dicts so freed slots
+                            # flow to remaining tasks on the next allocation.
+                            del task_by_name[task_name]
+                            del in_flight[task_name]
+                            del empty_futures[task_name]
+                            del empty_epochs[task_name]
+                            del task_epoch[task_name]
+                        else:
+                            # Postprocessing ran but task still needs more data.
+                            # Re-enter generation with a fresh empty_futures counter.
+                            task_epoch[task_name] += 1
+                            empty_futures[task_name] = 0
+                            in_flight[task_name] = 0
+                            epoch_attempts[task_name] = 0
+                            generating.add(task_name)
+                            self.logger.info(
+                                "Task '%s' re-entering generation (epoch %s).",
+                                task_name,
+                                task_epoch[task_name],
+                                extra={
+                                    "event": "task_requeued",
+                                    "task_name": task_name,
+                                    "epoch": task_epoch[task_name],
+                                },
                             )
 
-                            if task.is_complete() or stalled:
-                                if stalled and not task.is_complete():
-                                    self.logger.warning(
-                                        "Task %s has not generated any data in the last %s futures, moving to postprocessing",
-                                        task_name,
-                                        self._max_stalled_attempts,
-                                    )
-                                tasks_in_generation = [
-                                    t for t in tasks_in_generation if t.name != task_name
-                                ]
-                                tasks_finished_generation.append(task)
-                                in_flight_per_task.pop(task_name, None)
-                                # Do not reset consecutive_empty_futures here:
-                                # the epoch decision logic reads it to determine
-                                # stalled_generation reason.
-                            else:
-                                self._spawn_futures(
-                                    tasks_in_generation, futures, in_flight_per_task, executor
-                                )
-
-                finally:
-                    executor.shutdown(wait=True)
-
-                # ---------------------------------------------------------------
-                # Postprocessing phase.
-                # ---------------------------------------------------------------
-                tasks_for_postproc = [t for t in tasks_finished_generation if t.machine_data]
-                _counts_before: Dict[str, int] = {
-                    t.name: len(t.machine_data) for t in tasks_for_postproc
-                }
-
-                if tasks_for_postproc:
-                    self.logger.info("Launch postprocessing")
-                    with Span(
-                        "dgt.postprocessing",
-                        self._span_writer,
-                        parent_span_name="dgt.epoch",
-                        epoch=self._epoch,
-                        task_count=len(tasks_for_postproc),
-                    ):
-                        self.execute_postprocessing(tasks_for_postproc)
-
-                    for task in tasks_for_postproc:
-                        if task.machine_data:
-                            consecutive_empty_epochs[task.name] = 0
-                        else:
-                            consecutive_empty_epochs[task.name] += 1
-
-                    self.logger.info(
-                        "Postprocessing completed",
-                        extra={
-                            "event": "postprocessing_finished",
-                            "epoch": self._epoch,
-                            "task_counts": {
-                                t.name: {
-                                    "before": _counts_before[t.name],
-                                    "after": len(t.machine_data),
-                                }
-                                for t in tasks_for_postproc
-                            },
-                        },
+                    self._allocate_and_spawn(
+                        task_by_name,
+                        futures,
+                        task_epoch,
+                        in_flight,
+                        generating,
+                        pending_postproc,
+                        in_postproc,
+                        executor,
+                        epoch_spans,
+                        postproc_spans,
+                        epoch_attempts,
                     )
 
-                # ---------------------------------------------------------------
-                # Decide which tasks are done vs need another epoch.
-                # ---------------------------------------------------------------
-                _epoch_finish_reasons: Dict[str, str] = {}
-                next_active: List[GenerationTask] = []
-
-                for task in tasks_finished_generation:
-                    generation_stalled = (
-                        consecutive_empty_futures.get(task.name, 0) >= self._max_stalled_attempts
-                    )
-                    epoch_stalled = (
-                        consecutive_empty_epochs.get(task.name, 0) >= self._max_stalled_attempts
-                    )
-
-                    if task.is_complete():
-                        reason = "complete"
-                    elif generation_stalled:
-                        reason = "stalled_generation"
-                        self.logger.warning(
-                            "Task %s has not generated any data in the last %s attempts, terminating",
-                            task.name,
-                            self._max_stalled_attempts,
-                        )
-                    elif epoch_stalled:
-                        reason = "stalled_postprocessing"
-                        self.logger.warning(
-                            "Task %s has not produced any data after postprocessing in the last %s epochs, terminating",
-                            task.name,
-                            self._max_stalled_attempts,
-                        )
-                    else:
-                        # Still incomplete but not stalled: needs another epoch.
-                        next_active.append(task)
-                        continue
-
-                    _epoch_finish_reasons[task.name] = reason
-                    self.logger.info(
-                        "Task '%s' finished.",
-                        task.name,
-                        extra={
-                            "event": "task_finished",
-                            "task_name": task.name,
-                            "reason": reason,
-                            "produced": len(task.machine_data),
-                        },
-                    )
-                    task.finish()
-
-                self.logger.info(
-                    "Epoch %s finished.",
-                    self._epoch,
-                    extra={
-                        "event": "epoch_finished",
-                        "epoch": self._epoch,
-                        "task_counts": {
-                            t.name: len(t.machine_data) for t in tasks_finished_generation
-                        },
-                        "finish_reasons": _epoch_finish_reasons,
-                    },
-                )
-                self.logger.info("*" * 99)
-
-                active_tasks = next_active
-                if active_tasks and attempt <= self._num_attempts_to_complete:
-                    self.logger.info(
-                        "Triggering new epoch since %d task%s still pending.",
-                        len(active_tasks),
-                        "s are" if len(active_tasks) > 1 else " is",
-                    )
-                    self._epoch += 1
+        finally:
+            executor.shutdown(wait=True)
+            # Close any spans left open by an unexpected exit (e.g. exception).
+            for span in postproc_spans.values():
+                span.__exit__(None, None, None)
+            for span in epoch_spans.values():
+                span.__exit__(None, None, None)
+            for span in task_spans.values():
+                span.__exit__(None, None, None)
 
         self.logger.info("Generation took %.2fs", time.time() - start_time)
 
     # ===========================================================================
     #                       HELPERS
     # ===========================================================================
-    def _spawn_futures(
+    def _allocate_and_spawn(
         self,
-        active_tasks: List[GenerationTask],
-        futures: Dict[Future, str],
-        in_flight_per_task: Dict[str, int],
+        task_by_name: Dict[str, GenerationTask],
+        futures: Dict[Future, Any],
+        task_epoch: Dict[str, int],
+        in_flight: Dict[str, int],
+        generating: set,
+        pending_postproc: set,
+        in_postproc: set,
         executor: ThreadPoolExecutor,
+        epoch_spans: Dict[str, "Span"],
+        postproc_spans: Dict[str, "Span"],
+        epoch_attempts: Dict[str, int],
     ) -> None:
-        """Compute worker allocation and submit new futures for each task."""
-        spawn = self._compute_worker_allocation(active_tasks, in_flight_per_task)
+        """Submit new futures according to the priority allocation policy.
 
-        for task in active_tasks:
-            count = spawn.get(task.name, 0)
-            for _ in range(count):
-                batch = task.get_batch_examples()
-                if not batch:
-                    break
-                fut = executor.submit(contextvars.copy_context().run, self, self._epoch, batch)
-                futures[fut] = task.name
-                in_flight_per_task[task.name] = in_flight_per_task.get(task.name, 0) + 1
+        Step 1 (highest priority): each task in pending_postproc consumes one
+        worker slot and transitions to in_postproc. Opens a dgt.postprocessing
+        span for the task.
+
+        Step 2: remaining slots are distributed to generating tasks using
+        proportional fill with a per-task floor of 1. Opens a dgt.epoch span
+        the first time a gen future is submitted for a task in a given epoch.
+        """
+        in_flight_gen = sum(in_flight[n] for n in generating if n in in_flight)
+        in_flight_pp = sum(in_flight[n] for n in in_postproc if n in in_flight)
+        available = self._max_workers - in_flight_gen - in_flight_pp
+
+        # Step 1: postprocessing futures (priority).
+        for task_name in list(pending_postproc):
+            if available <= 0:
+                break
+            task = task_by_name[task_name]
+            pending_postproc.discard(task_name)
+            in_postproc.add(task_name)
+            in_flight[task_name] = in_flight.get(task_name, 0) + 1
+            epoch = task_epoch[task_name]
+            # Open dgt.postprocessing span for this postproc run.
+            if task_name not in postproc_spans:
+                span = Span(
+                    "dgt.postprocessing",
+                    self._span_writer,
+                    parent_span_name="dgt.task",
+                    task_name=task_name,
+                    epoch=epoch,
+                )
+                span.__enter__()
+                postproc_spans[task_name] = span
+            fut = executor.submit(self.execute_postprocessing, [task], epoch)
+            futures[fut] = (task_name, "postproc")
+            available -= 1
+
+        # Step 2: generation futures (proportional fill).
+        if available > 0 and generating:
+            generating_tasks = [task_by_name[n] for n in generating if n in task_by_name]
+            in_flight_generating = {n: in_flight.get(n, 0) for n in generating}
+            spawn = self._compute_worker_allocation(
+                generating_tasks, in_flight_generating, available
+            )
+            for task in generating_tasks:
+                count = spawn.get(task.name, 0)
+                for _ in range(count):
+                    batch = task.get_batch_examples()
+                    if not batch:
+                        # Seed data exhausted — treat as gen_stalled.
+                        generating.discard(task.name)
+                        pending_postproc.add(task.name)
+                        break
+                    # Open dgt.epoch span on the first future for this epoch.
+                    if in_flight.get(task.name, 0) == 0 and task.name not in epoch_spans:
+                        span = Span(
+                            "dgt.epoch",
+                            self._span_writer,
+                            parent_span_name="dgt.task",
+                            task_name=task.name,
+                            epoch=task_epoch[task.name],
+                        )
+                        span.__enter__()
+                        epoch_spans[task.name] = span
+                    fut = executor.submit(
+                        contextvars.copy_context().run, self, task_epoch[task.name], batch
+                    )
+                    futures[fut] = (task.name, "gen")
+                    in_flight[task.name] = in_flight.get(task.name, 0) + 1
+                    epoch_attempts[task.name] = epoch_attempts.get(task.name, 0) + 1
 
     def call_with_task_list(
         self, tasks: List[GenerationTask], request_idx: int

--- a/fms_dgt/core/blocks/validators/rouge.py
+++ b/fms_dgt/core/blocks/validators/rouge.py
@@ -1,6 +1,7 @@
 # Standard
 from dataclasses import dataclass
 from functools import partial
+from threading import Lock
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
 # Local
@@ -60,13 +61,14 @@ class RougeDedupValidator(ValidatorBlock):
                 )
         self._rouge_types = rouge_types
 
-        self._cache = dict()
+        self._cache: Dict[str, List] = {}
+        self._cache_lock = Lock()
         self._scorer = rouge_scorer.RougeScorer(["rougeL"], use_stemmer=False)
 
     def tokenize(self, inp: List | str):
         if isinstance(inp, list):
             return [self.tokenize(el) for el in inp]
-        else:
+        with self._cache_lock:
             if inp not in self._cache:
                 self._cache[inp] = self._scorer._tokenizer.tokenize(inp)
             return self._cache[inp]

--- a/fms_dgt/core/databuilders/conversation/generate.py
+++ b/fms_dgt/core/databuilders/conversation/generate.py
@@ -3,12 +3,16 @@
 
 # Standard
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Any, Dict, List, Set
 import contextvars
 import copy
 
 # Local
-from fms_dgt.base.databuilder.concurrent import ConcurrentGenerationDataBuilder
+from fms_dgt.base.databuilder.concurrent import (
+    ConcurrentGenerationDataBuilder,
+    ConcurrentGenerationDataBuilderConfig,
+)
 from fms_dgt.base.registry import register_data_builder
 from fms_dgt.core.databuilders.conversation.data_objects import (
     ConversationDataPoint,
@@ -17,6 +21,12 @@ from fms_dgt.core.databuilders.conversation.data_objects import (
 from fms_dgt.core.databuilders.conversation.registry import get_stage
 from fms_dgt.core.databuilders.conversation.stages.base import Stage
 from fms_dgt.core.databuilders.conversation.task import ConversationTask
+from fms_dgt.utils import init_dataclass_from_dict
+
+
+@dataclass(kw_only=True)
+class ConversationDataBuilderConfig(ConcurrentGenerationDataBuilderConfig):
+    max_concurrent_conversations: int = 8
 
 
 @register_data_builder("core/conversation")
@@ -50,7 +60,7 @@ class ConversationDataBuilder(ConcurrentGenerationDataBuilder):
     def __init__(
         self,
         *args: Any,
-        max_concurrent_conversations: int = 100,
+        config: ConversationDataBuilderConfig | dict | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize ConversationDataBuilder.
@@ -60,11 +70,13 @@ class ConversationDataBuilder(ConcurrentGenerationDataBuilder):
                 run in parallel within a single __call__ invocation. Controls
                 the inner thread pool size. Default: 8.
         """
-        super().__init__(*args, **kwargs)
+        config = init_dataclass_from_dict(config, ConversationDataBuilderConfig)
+        super().__init__(*args, config=config, **kwargs)
         self._max_concurrent_conversations = (
-            max_concurrent_conversations
-            if isinstance(max_concurrent_conversations, int) and max_concurrent_conversations > 0
-            else 100
+            config.max_concurrent_conversations
+            if isinstance(config.max_concurrent_conversations, int)
+            and config.max_concurrent_conversations > 0
+            else 8
         )
         # Track which tasks have had their stages initialized.
         self._stages_initialized: Set[str] = set()
@@ -332,7 +344,7 @@ class ConversationDataBuilder(ConcurrentGenerationDataBuilder):
             turn_count += 1
 
             # Log turn completion for all still-live contexts.
-            for ctx in live:
+            for data_point in live:
                 self.logger.debug(
                     "[%s] conversation %s turn %d/%d complete",
                     task.name,

--- a/fms_dgt/core/databuilders/conversation/stages/lm_assistant.py
+++ b/fms_dgt/core/databuilders/conversation/stages/lm_assistant.py
@@ -75,7 +75,9 @@ class NaiveAssistantStage(Stage):
         if not generator_inputs:
             return []
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        outputs = self._generator(
+            generator_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         results = []
         for out in outputs:

--- a/fms_dgt/core/databuilders/conversation/stages/lm_flow_controller.py
+++ b/fms_dgt/core/databuilders/conversation/stages/lm_flow_controller.py
@@ -4,6 +4,7 @@
 # Standard
 from typing import Any, Dict, List
 import json
+import random
 
 # Local
 from fms_dgt.core.blocks.llm.llm import LMProvider
@@ -22,35 +23,40 @@ from fms_dgt.core.databuilders.conversation.utils import (
 )
 
 
-def _build_fc_schema(pattern_names: List[str]) -> Dict:
+def _build_eligibility_schema(pattern_names: List[str]) -> Dict:
     return {
         "type": "object",
         "properties": {
             "reasoning": {
                 "type": "string",
-                "description": "Step-by-step reasoning about which patterns are coherent given the documents and conversation state.",
+                "description": "Step-by-step reasoning about which patterns are coherent given the scenario and conversation state.",
             },
             "eligible_patterns": {
                 "type": "array",
                 "items": {"type": "string", "enum": pattern_names},
                 "description": "Patterns that are coherent and possible given the current context.",
             },
-            "pattern": {
-                "type": "string",
-                "enum": pattern_names,
-                "description": "The single pattern selected for the next turn.",
-            },
-            "hint": {
-                "type": "string",
-                "description": "A short guide for the user stage on how to frame the next question or utterance, without revealing the answer.",
-            },
         },
-        "required": ["reasoning", "eligible_patterns", "pattern", "hint"],
+        "required": ["reasoning", "eligible_patterns"],
         "additionalProperties": False,
     }
 
 
-def _build_fc_messages(
+def _build_hint_schema() -> Dict:
+    return {
+        "type": "object",
+        "properties": {
+            "hint": {
+                "type": "string",
+                "description": "A short guide for the user on how to frame their next utterance.",
+            },
+        },
+        "required": ["hint"],
+        "additionalProperties": False,
+    }
+
+
+def _build_eligibility_messages(
     conversation_summary: str,
     patterns: Dict[str, Dict[str, str]],
     termination_patterns: List[str],
@@ -58,21 +64,14 @@ def _build_fc_messages(
     max_turns: int,
     pattern_history: List[str],
 ) -> list:
-    pattern_list = "\n".join(
-        f"- {name}: {info['description']}"
-        + (
-            f"\n  Example hint (contextualize for this conversation): {info['hint']}"
-            if info.get("hint")
-            else ""
-        )
-        for name, info in patterns.items()
-    )
+    pattern_list = "\n".join(f"- {name}: {info['description']}" for name, info in patterns.items())
+
     near_end = turn_count >= max(1, max_turns - 1)
     if near_end and termination_patterns:
         names = " or ".join(f"'{p}'" for p in termination_patterns)
         termination_note = (
             f"\nIMPORTANT: the conversation is near its maximum length. "
-            f"You MUST select {names} unless it is genuinely impossible."
+            f"You MUST include {names} in eligible_patterns unless it is genuinely impossible."
         )
     else:
         termination_note = ""
@@ -87,72 +86,109 @@ def _build_fc_messages(
 
     content = (
         "You are a conversation flow controller. "
-        "Your job is to decide what interaction pattern the user should follow next.\n\n"
+        "Your job is to identify which interaction patterns are valid for the next user turn.\n\n"
         "Follow these steps:\n"
         "1. Read the scenario and conversation history carefully.\n"
-        "2. Reason through each available pattern: is it coherent and applicable given the conversation context and the pattern's description? "
+        "2. Reason through each available pattern: is it coherent and applicable given the "
+        "conversation context and the pattern's description? "
         "Only mark a pattern as eligible if it genuinely fits the current state of the conversation. "
-        "Use the pattern history below to apply any consecutive-use or frequency caps stated in the pattern descriptions.\n"
-        "3. From the eligible patterns, select the one that best moves the conversation forward without repeating previous turns.\n"
-        "4. Write a short hint for the user that guides how to frame the next question or utterance. "
-        "Use the selected pattern's example hint as a starting point, but contextualize it for the specific scenario and conversation history. "
-        "The hint must not reveal the answer and must not repeat something already asked.\n\n"
+        "Use the pattern history below to apply any consecutive-use or frequency caps stated in "
+        "the pattern descriptions.\n\n"
         f"Conversation so far:\n{conversation_summary or '(conversation not started yet)'}\n"
         f"{pattern_history_section}\n"
         f"Available patterns:\n{pattern_list}"
         f"{termination_note}\n\n"
-        "Return a JSON object with: reasoning, eligible_patterns (list of pattern names that fit), "
-        "pattern (your chosen pattern), and hint (guidance for the user stage)."
+        "Return a JSON object with: reasoning and eligible_patterns (list of pattern names that fit)."
     )
+
     return [{"role": "user", "content": content}]
 
 
-def _parse_fc_output(
-    raw: str, patterns: Dict[str, Dict[str, str]]
-) -> tuple[str | None, str | None, List[str], str | None]:
-    """Parse LM output into (pattern_name, hint, eligible_patterns, reasoning).
+def _build_hint_messages(
+    conversation_summary: str,
+    pattern_name: str,
+    static_hint: str | None,
+) -> list:
+    if static_hint:
+        hint_guidance = (
+            f"Hint template: {static_hint}\n"
+            "Contextualise the hint template for the specific scenario, and "
+            "conversation so far."
+        )
+    else:
+        hint_guidance = (
+            f"There is no hint template for this pattern. "
+            f"Write a hint that guides the user on how to frame their next utterance "
+            f"following the '{pattern_name}' pattern, contextualised to the specific "
+            "scenario and conversation so far."
+        )
 
-    Tries JSON parse first. Falls back to substring match on pattern names
-    for providers that ignore response_format, returning empty eligible list
-    and None for hint and reasoning.
+    content = (
+        "You are a conversation flow controller. "
+        "Your job is to write a hint that guides the user on how to frame their next utterance.\n\n"
+        f"Selected pattern: {pattern_name}\n"
+        f"{hint_guidance}\n\n"
+        "The hint must not reveal the answer and must not repeat something already asked.\n\n"
+        f"Conversation so far:\n{conversation_summary or '(conversation not started yet)'}\n\n"
+        "Return a JSON object with a single 'hint' field containing the hint text."
+    )
+
+    return [{"role": "user", "content": content}]
+
+
+def _parse_eligibility_output(
+    raw: str, patterns: Dict[str, Dict[str, str]]
+) -> tuple[List[str], str | None]:
+    """Parse LM output into (eligible_patterns, reasoning).
+
+    Tries JSON parse first. Falls back to treating all patterns as eligible
+    for providers that ignore response_format.
     """
     try:
         parsed = json.loads(raw)
-        pattern = parsed.get("pattern", "").strip()
-        hint = parsed.get("hint", "").strip() or None
         reasoning = parsed.get("reasoning", "").strip() or None
         eligible = [p for p in parsed.get("eligible_patterns", []) if p in patterns]
-        if pattern in patterns:
-            return pattern, hint, eligible, reasoning
+        return eligible, reasoning
     except (json.JSONDecodeError, AttributeError):
         pass
-    # Fallback: substring match
-    raw_stripped = raw.strip()
-    if raw_stripped in patterns:
-        return raw_stripped, None, [], None
-    for name in patterns:
-        if name in raw_stripped:
-            return name, None, [], None
-    return None, None, [], None
+
+    # Fallback: treat all patterns as eligible
+    return list(patterns.keys()), None
 
 
 @register_stage("lm/flow_controller")
 class LMFlowControllerStage(Stage):
     """Iteration stage that selects the next interaction pattern.
 
+    Uses two LM calls per turn:
+        - Call 1: LM reasons about which patterns are eligible given the current
+        conversation state. Returns eligible_patterns and reasoning.
+        - Code: weighted random sampling via random.choices selects the pattern
+        from the eligible set using per-pattern weights.
+        - Call 2: LM generates a contextualised hint for the selected pattern,
+        using the static hint template from config as a starting point and
+        adapting it to the specific scenario and conversation history.
+
     Appends a FlowControllerStep with:
-      - content: the chosen pattern name
-      - terminate: True when a termination pattern is selected
-      - hint: the pattern's hint text for the user stage
+        - content: the chosen pattern name
+        - terminate: True when a termination pattern is selected
+        - hint: contextualised hint text for the user stage
 
     Drops the data point on LM parse failure (returns empty list for that point).
 
     Config kwargs:
         patterns: Required. List of dicts, each with:
             - ``name``: pattern identifier (required)
-            - ``description``: shown to the LM so it can choose this pattern (required)
-            - ``hint``: passed to the user stage to guide turn generation (required)
-            - ``weight``: optional float, reserved for future weighted sampling
+            - ``description``: shown to the LM for eligibility reasoning (required)
+            - ``hint``: optional static hint template. If provided, the LM uses it
+              as a starting point and contextualises it for the specific conversation.
+              If omitted, the LM generates a hint from scratch based on the pattern
+              name and conversation context. Used as fallback if the hint LM call fails.
+            - ``weight``: optional float. Controls relative sampling probability
+              among eligible patterns. Treated as a ratio, not a probability —
+              a pattern with weight 3.0 is three times as likely to be selected
+              as one with weight 1.0. Weights do not need to sum to 1. Defaults
+              to 1.0 (uniform sampling across eligible patterns).
         termination_patterns: List of pattern names that signal conversation end.
             Must be a subset of the names listed in ``patterns``. Required.
         max_turns: Passed through from the task so the FC can signal early
@@ -170,16 +206,18 @@ class LMFlowControllerStage(Stage):
         **kwargs: Any,
     ) -> None:
         super().__init__(name=name)
+
         self._generator = generator
         self._max_turns = max_turns
         self._termination_patterns: List[str] = termination_patterns
-
         self._patterns: Dict[str, Dict[str, str]] = {}
+
         for p in patterns:
             pname = p["name"]
             self._patterns[pname] = {
                 "description": p.get("description", pname),
-                "hint": p.get("hint", f"Generate a user turn following the '{pname}' pattern."),
+                "hint": p.get("hint"),  # None if not specified; used as template for call 2
+                "weight": float(p.get("weight", 1.0)),
             }
 
         pattern_names = list(self._patterns.keys())
@@ -188,23 +226,35 @@ class LMFlowControllerStage(Stage):
             "json_schema": {
                 "name": "flow_controller",
                 "strict": True,
-                "schema": _build_fc_schema(pattern_names),
+                "schema": _build_eligibility_schema(pattern_names),
+            },
+        }
+        self._hint_response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "hint_generator",
+                "strict": True,
+                "schema": _build_hint_schema(),
             },
         }
 
     def _build_conversation_summary(self, context: ConversationDataPoint) -> str:
         """Return a condensed text representation of the conversation so far.
 
-        Override in subclasses to inject additional context (e.g. document text
-        for RAG-specific eligibility reasoning).
+        Override in subclasses to inject additional context (e.g. document text,
+        retrieved passages, or other scenario-specific state needed for eligibility
+        reasoning).
         """
         lines = []
+
         scenario_step = get_last_step_of_type(context.steps, ScenarioStep)
         if scenario_step:
             lines.append(f"[Scenario]\n{scenario_step.content}")
+
         history = steps_to_text(context.steps)
         if history:
             lines.append(history)
+
         return "\n".join(lines)
 
     def __call__(
@@ -213,11 +263,13 @@ class LMFlowControllerStage(Stage):
         seed_data: List[ConversationDataPoint] | None = None,
         **kwargs,
     ) -> List[ConversationDataPoint]:
-        generator_inputs = []
+
+        # --- Call 1: eligibility ---
+        eligibility_inputs = []
         for data_point in data_points:
-            generator_inputs.append(
+            eligibility_inputs.append(
                 {
-                    "input": _build_fc_messages(
+                    "input": _build_eligibility_messages(
                         self._build_conversation_summary(data_point),
                         self._patterns,
                         self._termination_patterns,
@@ -238,28 +290,95 @@ class LMFlowControllerStage(Stage):
                 }
             )
 
-        if not generator_inputs:
+        if not eligibility_inputs:
             return []
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        eligibility_outputs = self._generator(
+            eligibility_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
-        results = []
-        for out in outputs:
+        # --- Weighted sampling ---
+        # Build hint inputs only for data points that parsed successfully.
+        hint_inputs = []
+
+        for out in eligibility_outputs:
             result = out.get("result") or ""
             if isinstance(result, dict):
                 result = result.get("content") or ""
             raw = result.strip()
-            pattern_name, hint, eligible_patterns, reasoning = _parse_fc_output(raw, self._patterns)
-            if pattern_name is None:
+
+            eligible_patterns, reasoning = _parse_eligibility_output(raw, self._patterns)
+
+            if not eligible_patterns:
                 continue
+
+            # Select a pattern based on stated preference
+            selected_pattern = random.choices(
+                eligible_patterns,
+                weights=[self._patterns[p]["weight"] for p in eligible_patterns],
+                k=1,
+            )[0]
+
             data_point: ConversationDataPoint = out["reference"]
-            terminate = pattern_name in self._termination_patterns
-            # LM-generated hint takes precedence; fall back to static hint from config.
+            hint_inputs.append(
+                {
+                    "input": _build_hint_messages(
+                        self._build_conversation_summary(data_point),
+                        selected_pattern,
+                        self._patterns[selected_pattern]["hint"],
+                    ),
+                    "gen_kwargs": {
+                        "max_new_tokens": 256,
+                        "response_format": self._hint_response_format,
+                    },
+                    "reference": data_point,
+                    "task_name": data_point.task_name,
+                    "eligible_patterns": eligible_patterns,
+                    "reasoning": reasoning,
+                    "selected_pattern": selected_pattern,
+                }
+            )
+
+        if not hint_inputs:
+            return []
+
+        # --- Call 2: hint generation ---
+        hint_outputs = self._generator(
+            hint_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
+
+        # --- Assemble results ---
+        results = []
+        for hint_out in hint_outputs:
+            # Extract reference fields
+            data_point = hint_out.get("reference")
+            eligible_patterns = hint_out.get("eligible_patterns")
+            reasoning = hint_out.get("reasoning")
+            selected_pattern = hint_out.get("selected_pattern")
+
+            # Parse hint result
+            hint_result = hint_out.get("result") or ""
+            if isinstance(hint_result, dict):
+                hint_result = hint_result.get("content") or ""
+            raw_hint = hint_result.strip()
+            hint = None
+            try:
+                hint = json.loads(raw_hint).get("hint", "").strip() or None
+            except (json.JSONDecodeError, AttributeError):
+                hint = raw_hint or None
+
+            # Fall back to static hint template if LM hint generation failed.
+            # If no static hint exists, fall back to a generic placeholder.
             if not hint:
-                hint = self._patterns[pattern_name].get("hint")
+                hint = self._patterns[selected_pattern]["hint"] or (
+                    f"Generate a user utterance following the '{selected_pattern}' pattern."
+                )
+
+            terminate = selected_pattern in self._termination_patterns
+
             data_point.steps.append(
                 FlowControllerStep(
-                    content=pattern_name,
+                    content=selected_pattern,
                     stage_name=self.name,
                     terminate=terminate,
                     hint=hint,
@@ -268,4 +387,5 @@ class LMFlowControllerStage(Stage):
                 )
             )
             results.append(data_point)
+
         return results

--- a/fms_dgt/core/databuilders/conversation/stages/lm_scenario.py
+++ b/fms_dgt/core/databuilders/conversation/stages/lm_scenario.py
@@ -76,7 +76,9 @@ class LMScenarioStage(Stage):
                 }
             )
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        outputs = self._generator(
+            generator_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         results = []
         for out in outputs:

--- a/fms_dgt/core/databuilders/conversation/stages/lm_user.py
+++ b/fms_dgt/core/databuilders/conversation/stages/lm_user.py
@@ -118,7 +118,9 @@ class GuidedUserStage(Stage):
         if not generator_inputs:
             return []
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        outputs = self._generator(
+            generator_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         results = []
         for out in outputs:

--- a/fms_dgt/core/tools/engines/search/samplers/random.py
+++ b/fms_dgt/core/tools/engines/search/samplers/random.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Literal, Optional
 import random
 
 # Local
+from fms_dgt.core.tools.constants import TOOL_DEFAULT_NAMESPACE
 from fms_dgt.core.tools.data_objects import ToolCall
 from fms_dgt.core.tools.engines.search.base import Document, SearchToolEngine
 from fms_dgt.core.tools.engines.search.samplers.base import (
@@ -194,7 +195,12 @@ class RandomDocumentSampler(DocumentSampler):
         return random.sample(pool, min(k, len(pool)))
 
     def _sample_engine(self, session_id: str, k: int) -> List[Document]:
-        tc = ToolCall(name="sample", arguments={"size": k}, call_id=None)
+        tc = ToolCall(
+            name="sample",
+            namespace=TOOL_DEFAULT_NAMESPACE,
+            arguments={"size": k},
+            call_id=None,
+        )
         results = self._engine.simulate(session_id=session_id, tool_calls=[tc])
         if not results or results[0].result is None:
             return []

--- a/fms_dgt/core/tools/samplers/neighbor.py
+++ b/fms_dgt/core/tools/samplers/neighbor.py
@@ -45,21 +45,27 @@ class NeighborToolSampler(ToolSampler):
         ``tc/fan_in``, and ``tc/fan_out`` samplers once the ``dataflow``
         enrichment is available.  See the tool subsystem design discussion.
 
-    Selects one seed tool then fills the remaining k-1 slots from that seed's
-    neighbors, weighted by their compatibility scores.
+    Picks a seed tool to anchor a BFS over the neighbor graph, assembles the
+    seed's connected component (seed plus tools reachable within a fixed
+    number of expansion rounds), and draws ``k`` tools from that pool.
+
+    The seed is the starting point for neighbor expansion; it is a member of
+    the returned pool like any other tool, with no guaranteed position in the
+    output and no guarantee of being included when ``k`` is small relative to
+    the pool size.
 
     **Seed selection:** a namespace is drawn according to the configured
     distribution (``namespace``, ``namespace_weights``, ``strategy``), then
     one tool is chosen uniformly at random within that namespace.
 
-    **Neighbor sampling:** neighbors are drawn without replacement, weighted
-    by softmax-normalized compatibility scores.  Neighbors span all namespaces.
-    If fewer than k-1 neighbors exist, all available neighbors are returned
-    alongside the seed and a warning is logged.
+    **Pool sampling:** ``k`` tools are drawn without replacement from the
+    connected-component pool, weighted by softmax-normalized compatibility
+    scores. If the pool holds fewer than ``k`` tools, all of them are
+    returned and a warning is logged.
 
     Args:
         registry: The ``ToolRegistry`` to sample from.
-        k: Default number of tools to sample (seed + k-1 neighbors).
+        k: Default number of tools to sample.
             Required unless every ``sample()`` call provides ``k`` explicitly.
         namespace: Hard-filter seed selection to a single namespace.
         namespace_weights: Per-namespace relative weights for seed namespace
@@ -243,7 +249,7 @@ class NeighborToolSampler(ToolSampler):
         use_seed_namespace: Optional[bool] = True,
         **kwargs: Any,
     ) -> List[Tool]:
-        """Sample up to ``k`` tools: one seed plus k-1 neighbors.
+        """Sample up to ``k`` tools from the seed's connected component.
 
         Call-site arguments override constructor defaults for this call only.
 
@@ -260,8 +266,12 @@ class NeighborToolSampler(ToolSampler):
                 in same namespace as selected seed
 
         Returns:
-            List of sampled ``Tool`` instances.  First element is the seed.
-            Length is ``min(k, 1 + available_neighbors)``.
+            List of sampled ``Tool`` instances drawn from the connected
+            component of the seed.  Length is ``min(k, pool_size)``, where
+            ``pool_size`` is the number of tools reachable from the seed
+            within the BFS expansion rounds. The seed is part of the pool
+            but has no privileged position in the result and is not
+            guaranteed to appear when ``k`` is smaller than ``pool_size``.
         """
         resolved_k = self._resolve_k(k)
         resolved_ns = namespace if namespace is not None else self._default_namespace
@@ -294,11 +304,11 @@ class NeighborToolSampler(ToolSampler):
         selected_neighbors: List[Tool] = []
         nogoods = set()
 
-        want = resolved_k - 1
+        want = resolved_k
         if want > len(neighbors):
             self.logger.warning(
-                "tc/neighbor: requested k=%d but seed %r has only %d neighbor(s); "
-                "returning seed + all available neighbors.",
+                "tc/neighbor: requested k=%d but seed %r has only %d tool(s) in "
+                "its connected component; returning all available tools.",
                 resolved_k,
                 seed.qualified_name,
                 len(neighbors),

--- a/fms_dgt/public/databuilders/examples/qa/generate.py
+++ b/fms_dgt/public/databuilders/examples/qa/generate.py
@@ -104,7 +104,7 @@ class GeographyQADataBuilder(GenerationDataBuilder):
         # LMProvider runs requests asynchronously for throughput.
         # Switch method="completion" and pass a plain string input (Option B above)
         # to use the text-completion endpoint instead.
-        generator_outputs = self.generator(generator_inputs, method="chat_completion")
+        generator_outputs = self.generator(generator_inputs, method=LMProvider.CHAT_COMPLETION)
 
         # Process outputs from block
         outputs = []

--- a/fms_dgt/public/databuilders/examples/rater/generate.py
+++ b/fms_dgt/public/databuilders/examples/rater/generate.py
@@ -76,7 +76,7 @@ class RatingDataBuilder(TransformationDataBuilder):
 
         # Execute block
         # LMProvider runs requests asynchronously for throughput.
-        rater_outputs = self.rater(rater_inputs, method="chat_completion")
+        rater_outputs = self.rater(rater_inputs, method=LMProvider.CHAT_COMPLETION)
 
         # Process outputs from block
         outputs = []

--- a/fms_dgt/public/databuilders/rag/stages/lm_assistant_live.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_assistant_live.py
@@ -146,7 +146,9 @@ class LiveRetrievalAssistantStage(Stage):
         if not call1_inputs:
             return []
 
-        call1_outputs = self._generator(call1_inputs, method="chat_completion", disable_tqdm=True)
+        call1_outputs = self._generator(
+            call1_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         # Partition by whether model called a tool or responded with content.
         tool_call_batch: List[tuple] = []  # (ctx, tool_calls list)
@@ -229,7 +231,9 @@ class LiveRetrievalAssistantStage(Stage):
             for ctx, _ in synthesis_batch
         ]
 
-        call2_outputs = self._generator(call2_inputs, method="chat_completion", disable_tqdm=True)
+        call2_outputs = self._generator(
+            call2_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         synthesis_results: List[ConversationDataPoint] = []
         for out in call2_outputs:

--- a/fms_dgt/public/databuilders/rag/stages/lm_assistant_live.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_assistant_live.py
@@ -19,6 +19,7 @@ from fms_dgt.core.databuilders.conversation.data_objects import (
 )
 from fms_dgt.core.databuilders.conversation.registry import register_stage
 from fms_dgt.core.databuilders.conversation.stages.base import Stage
+from fms_dgt.core.tools.constants import TOOL_DEFAULT_NAMESPACE
 from fms_dgt.core.tools.data_objects import ToolCall
 from fms_dgt.core.tools.engines.composite import CompositeToolEngine
 
@@ -128,7 +129,7 @@ class LiveRetrievalAssistantStage(Stage):
         seed_data: List[ConversationDataPoint] | None = None,
         **kwargs: Any,
     ) -> List[ConversationDataPoint]:
-        tools = self._engine.catalog.to_dicts(qualified=True)
+        tools = self._engine.catalog.to_dicts(qualified=False)
 
         # LM call #1: present full conversation history + all tools, let model decide.
         call1_inputs = [
@@ -178,23 +179,29 @@ class LiveRetrievalAssistantStage(Stage):
         # Execute tool calls and collect retrieved results for synthesis.
         synthesis_batch: List[tuple] = []  # (ctx, list of tool results)
 
+        catalog = self._engine.catalog
         for ctx, raw_tool_calls in tool_call_batch:
             tool_calls = []
             for tc in raw_tool_calls:
                 fn = tc.get("function", {})
-                tool_calls.append(
-                    ToolCall(
-                        name=fn.get("name", ""),
-                        arguments=fn.get("arguments", {}),
-                        call_id=tc.get("id") or str(uuid.uuid4()),
-                    )
+                name = fn.get("name", "")
+                # FIXME(tc-team): unqualified names prompted to the LM are
+                # ambiguous if the catalog has name collisions across
+                # namespaces. This lookup takes the first match and may pick
+                # the wrong namespace. Safe today because RAG typically runs
+                # against a single-namespace catalog, but needs a principled
+                # fix (e.g., stage-init validation, or a schema convention
+                # that disambiguates without exposing namespaces to the LM).
+                match = next((t for t in catalog.all_tools() if t.name == name), None)
+                namespace = match.namespace if match else TOOL_DEFAULT_NAMESPACE
+                tool_call = ToolCall(
+                    name=name,
+                    namespace=namespace,
+                    arguments=fn.get("arguments", {}),
+                    call_id=tc.get("id") or str(uuid.uuid4()),
                 )
-                ctx.steps.append(
-                    ToolCallStep(
-                        content=dataclasses.asdict(tool_calls[-1]),
-                        stage_name=self.name,
-                    )
-                )
+                tool_calls.append(tool_call)
+                ctx.steps.append(ToolCallStep(content=tool_call.to_dict(), stage_name=self.name))
 
             try:
                 tool_results = self._engine.execute(

--- a/fms_dgt/public/databuilders/rag/stages/lm_assistant_static.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_assistant_static.py
@@ -2,37 +2,87 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Standard
-from typing import Any, List
+from typing import Any, Dict, List
+import json
+import logging
 
 # Local
 from fms_dgt.core.blocks.llm.llm import LMProvider
 from fms_dgt.core.databuilders.conversation.data_objects import (
     AssistantStep,
     ConversationDataPoint,
-    ScenarioStep,
-    UserStep,
+    Step,
 )
 from fms_dgt.core.databuilders.conversation.registry import register_stage
 from fms_dgt.core.databuilders.conversation.stages.base import Stage
-from fms_dgt.core.databuilders.conversation.utils import get_last_step_of_type
+from fms_dgt.core.databuilders.conversation.utils import (
+    get_last_step_of_type,
+    steps_to_messages,
+)
 from fms_dgt.public.databuilders.rag.data_objects import RAGScenarioStep
+from fms_dgt.public.databuilders.rag.utils import render_documents
+
+logger = logging.getLogger(__name__)
+
+# ===========================================================================
+#                       CONSTANTS
+# ===========================================================================
+_MAX_RETRIES = 3
 
 
-def _render_documents(documents: List[dict]) -> str:
-    parts = []
-    for i, doc in enumerate(documents, start=1):
-        text = doc.get("text", "")
-        doc_id = doc.get("id", str(i))
-        parts.append(f"[Document {i} | id={doc_id}]\n{text}")
-    return "\n\n".join(parts) if parts else "(no documents provided)"
+_CRITIQUE_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "rag_critique",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "reasoning": {
+                    "type": "string",
+                    "description": (
+                        "For each factual claim in the assistant response, quote the specific "
+                        "sentence or sentences from the documents that ground it, or explain "
+                        "the logical derivation from document content. If no document sentence "
+                        "grounds a claim and it requires outside knowledge to reach, mark it "
+                        "as unsupported. Refusals and partial answer acknowledgments "
+                        "(e.g. 'the documents do not cover this') are always supported."
+                    ),
+                },
+                "valid": {
+                    "type": "string",
+                    "enum": ["yes", "no"],
+                    "description": (
+                        "Is every factual claim in the assistant response grounded in the "
+                        "provided documents, either as a direct statement or a logical "
+                        "derivation from what the documents say, or explicitly acknowledged "
+                        "as outside document scope? Answer 'yes' or 'no'."
+                    ),
+                },
+                "issues": {
+                    "type": "string",
+                    "description": (
+                        "If valid is 'no', describe the specific ungrounded claims. "
+                        "If valid is 'yes', leave empty."
+                    ),
+                },
+            },
+            "required": ["reasoning", "valid", "issues"],
+            "additionalProperties": False,
+        },
+    },
+}
 
 
-def _build_static_assistant_messages(
-    scenario: str,
+# ===========================================================================
+#                       HELPER METHODS
+# ===========================================================================
+
+
+def _build_generate_input(
     documents: List[dict],
-    history_steps: list,
+    steps: List[Step],
 ) -> list:
-    doc_text = _render_documents(documents)
     system_content = (
         "You are a helpful AI assistant. Answer questions using only the provided documents.\n\n"
         "Follow these rules strictly:\n"
@@ -43,17 +93,100 @@ def _build_static_assistant_messages(
         "- Only say the documents cannot answer if there is genuinely no relevant information "
         "at all (not merely because the answer is incomplete).\n"
         "Never fabricate facts, numbers, names, or policies not present in the documents."
-        f"\n\nContext documents:\n{doc_text}"
+        f"\n\nContext documents:\n{render_documents(documents)}"
     )
-    if scenario:
-        system_content = f"Scenario: {scenario}\n\n" + system_content
     messages = [{"role": "system", "content": system_content}]
-    for step in history_steps:
-        if isinstance(step, UserStep):
-            messages.append({"role": "user", "content": step.content})
-        elif isinstance(step, AssistantStep):
-            messages.append({"role": "assistant", "content": step.content})
+    messages.extend(steps_to_messages(steps))
     return messages
+
+
+def _build_critique_input(
+    conversation: List[dict],
+    assistant_response: str,
+    documents: List[dict],
+) -> list:
+    doc_text = render_documents(documents)
+    system_content = (
+        "You are a strict grounding evaluator for RAG assistant responses. "
+        "Your job is to verify that every factual claim in the assistant response is grounded "
+        "in the provided documents.\n\n"
+        "A response is valid if:\n"
+        "- Every factual claim is grounded in the documents, either as a direct statement or "
+        "a logical derivation from what the documents say.\n"
+        "- Any gap is explicitly framed as a refusal or partial answer (e.g. 'the documents "
+        "do not cover this', 'based on the documents I can only confirm...').\n\n"
+        "A response is NOT valid if:\n"
+        "- Any factual claim requires domain knowledge or background facts not present "
+        "in the documents to reach. Pure logical or definitional derivations from "
+        "document content are acceptable.\n"
+        "- It presents speculative or uncertain information as definitive fact without "
+        "the documents supporting that certainty.\n\n"
+        f"Documents:\n{doc_text}"
+    )
+    messages = [{"role": "system", "content": system_content}]
+    messages.extend(conversation)
+    messages.append({"role": "assistant", "content": assistant_response})
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                "Evaluate the assistant response above. For each factual claim, quote the "
+                "specific sentence or sentences from the documents that support it. If no "
+                "sentence supports a claim, note it as unsupported. "
+                "Return a JSON object following the schema."
+            ),
+        }
+    )
+    return messages
+
+
+def _build_rewrite_input(
+    documents: List[dict],
+    steps: List[Step],
+    failed_response: str,
+    issues: str,
+) -> list:
+    system_content = (
+        "You are a helpful AI assistant. Answer questions using only the provided documents.\n\n"
+        "Follow these rules strictly:\n"
+        "- If the documents fully answer the question, answer directly and completely.\n"
+        "- If the documents partially answer the question, state what the documents do say, "
+        "then clearly note what specific information is missing. Do not invent or infer details "
+        "beyond what the documents contain.\n"
+        "- Only say the documents cannot answer if there is genuinely no relevant information "
+        "at all (not merely because the answer is incomplete).\n"
+        "Never fabricate facts, numbers, names, or policies not present in the documents."
+        f"\n\nContext documents:\n{render_documents(documents)}"
+    )
+    messages = [{"role": "system", "content": system_content}]
+    messages.extend(steps_to_messages(steps))
+
+    messages.append({"role": "assistant", "content": failed_response})
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                "[REWRITE REQUEST] The assistant response above does not meet grounding "
+                f"requirements. {issues} "
+                "Please rewrite the assistant response so that every claim is grounded "
+                "in the provided documents, or explicitly states what the documents do "
+                "not cover."
+            ),
+        }
+    )
+    return messages
+
+
+def _parse_critique(raw: str) -> Dict[str, str]:
+    try:
+        parsed = json.loads(raw)
+        return {
+            "valid": parsed.get("valid", "no").strip().lower(),
+            "issues": parsed.get("issues", "").strip(),
+            "reasoning": parsed.get("reasoning", "").strip(),
+        }
+    except (json.JSONDecodeError, AttributeError):
+        return {"valid": "no", "issues": "Could not parse critique output.", "reasoning": ""}
 
 
 @register_stage("lm/assistant/rag/static")
@@ -64,13 +197,43 @@ class StaticContextAssistantStage(Stage):
     and injects the documents into the system prompt. The assistant generates a
     response that is grounded in those documents.
 
+    After each generation, a critique call using the same LM validates that every
+    claim is traceable to the provided documents or explicitly acknowledged as outside
+    scope. On failure, a rewrite is requested with the critique issues injected back
+    into the conversation. This repeats up to ``max_retries`` times (default 1,
+    capped at 3). Data points that fail all retries are dropped.
+
     No retrieval tool calls are produced. The conversation output contains only
     user and assistant turns, training grounded synthesis and faithfulness.
+
+    Config kwargs:
+        max_retries: Number of rewrite attempts on critique failure. Default 1, max 3.
     """
 
-    def __init__(self, *, name: str, generator: LMProvider, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        name: str,
+        generator: LMProvider,
+        max_retries: int = 1,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(name=name)
         self._generator = generator
+        self._max_retries = min(max(0, max_retries), _MAX_RETRIES)
+
+    def _generate(self, inputs: List[Dict], max_new_tokens: int = 1024) -> List[Dict]:
+        for inp in inputs:
+            inp["gen_kwargs"] = {"max_new_tokens": max_new_tokens}
+        return self._generator(inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True)
+
+    def _critique(self, inputs: List[Dict]) -> List[Dict]:
+        for inp in inputs:
+            inp["gen_kwargs"] = {
+                "max_new_tokens": 512,
+                "response_format": _CRITIQUE_RESPONSE_FORMAT,
+            }
+        return self._generator(inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True)
 
     def __call__(
         self,
@@ -78,43 +241,104 @@ class StaticContextAssistantStage(Stage):
         seed_data: List[ConversationDataPoint] | None = None,
         **kwargs: Any,
     ) -> List[ConversationDataPoint]:
-        generator_inputs = []
+        active: List[Dict] = []
         for data_point in data_points:
-            rag_step = get_last_step_of_type(data_point.steps, RAGScenarioStep)
-            if rag_step:
-                scenario = rag_step.content
-                documents = rag_step.documents
-            else:
-                scenario_step = get_last_step_of_type(data_point.steps, ScenarioStep)
-                scenario = scenario_step.content if scenario_step else ""
-                documents = []
+            documents = []
+            scenario_step: RAGScenarioStep = get_last_step_of_type(
+                data_point.steps, RAGScenarioStep
+            )
+            if scenario_step:
+                documents: List[dict] = scenario_step.documents
 
-            history_steps = [
-                step for step in data_point.steps if isinstance(step, (UserStep, AssistantStep))
-            ]
-            generator_inputs.append(
+            active.append(
                 {
-                    "input": _build_static_assistant_messages(scenario, documents, history_steps),
-                    "gen_kwargs": {"max_new_tokens": 1024},
+                    "input": _build_generate_input(documents, data_point.steps),
+                    "documents": documents,
                     "reference": data_point,
                     "task_name": data_point.task_name,
+                    "attempt": 1,
                 }
             )
 
-        if not generator_inputs:
+        if not active:
             return []
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
-
         results = []
-        for out in outputs:
-            result = out.get("result") or ""
-            if isinstance(result, dict):
-                result = result.get("content") or ""
-            assistant_text = result.strip()
-            if not assistant_text:
-                continue
-            data_point: ConversationDataPoint = out["reference"]
-            data_point.steps.append(AssistantStep(content=assistant_text, stage_name=self.name))
-            results.append(data_point)
+
+        while active:
+            generated_outputs = self._generate(active)
+
+            critique_inputs = []
+            for entry in generated_outputs:
+                parsed_output = entry.get("result") or ""
+                if isinstance(parsed_output, dict):
+                    parsed_output = parsed_output.get("content") or ""
+                response = parsed_output.strip()
+                if not response:
+                    continue
+                critique_inputs.append({**entry, "response": response})
+
+            if not critique_inputs:
+                break
+
+            critique_outputs = self._critique(
+                [
+                    {
+                        "input": _build_critique_input(
+                            conversation=steps_to_messages(entry["reference"].steps),
+                            assistant_response=entry["response"],
+                            documents=entry["documents"],
+                        ),
+                        **entry,
+                    }
+                    for entry in critique_inputs
+                ]
+            )
+
+            next_active = []
+            for entry in critique_outputs:
+                critique_result = entry.get("result") or ""
+                if isinstance(critique_result, dict):
+                    critique_result = critique_result.get("content") or ""
+                critique = _parse_critique(critique_result.strip())
+
+                if critique["valid"] == "yes":
+                    data_point: ConversationDataPoint = entry["reference"]
+                    data_point.steps.append(
+                        AssistantStep(
+                            content=entry["response"],
+                            stage_name=self.name,
+                            metadata={
+                                "critique_attempts": entry["attempt"],
+                                "critique_reasoning": critique["reasoning"],
+                            },
+                        )
+                    )
+                    results.append(data_point)
+                elif entry["attempt"] <= self._max_retries:
+                    next_active.append(
+                        {
+                            **entry,
+                            "input": _build_rewrite_input(
+                                entry["documents"],
+                                entry["reference"].steps,
+                                entry["response"],
+                                critique["issues"],
+                            ),
+                            "attempt": entry["attempt"] + 1,
+                        }
+                    )
+                else:
+                    logger.debug(
+                        "Dropping conversation %s after %d attempts.\n"
+                        "  Issues: %s\n"
+                        "  Reasoning: %s",
+                        entry["reference"].conversation_id,
+                        entry["attempt"],
+                        critique["issues"],
+                        critique["reasoning"],
+                    )
+
+            active = next_active
+
         return results

--- a/fms_dgt/public/databuilders/rag/stages/lm_flow_controller_rag.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_flow_controller_rag.py
@@ -35,8 +35,10 @@ class RAGFlowControllerStage(LMFlowControllerStage):
             documents = getattr(scenario_step, "documents", []) or []
             if documents:
                 doc_text = render_documents(documents)
-                lines.append(f"\n[Documents]\n{doc_text}")
+                lines.append(f"\n[Available Documents]\n{doc_text}")
         history = steps_to_text(context.steps)
         if history:
-            lines.append(history)
+            lines.append(f"\n[Conversation History]\n{history}")
+        else:
+            lines.append("\n[Conversation History]\n(no turns yet — conversation has not started)")
         return "\n".join(lines)

--- a/fms_dgt/public/databuilders/rag/stages/lm_flow_controller_rag.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_flow_controller_rag.py
@@ -14,15 +14,7 @@ from fms_dgt.core.databuilders.conversation.utils import (
     get_last_step_of_type,
     steps_to_text,
 )
-
-
-def _render_documents(documents: list) -> str:
-    parts = []
-    for i, doc in enumerate(documents, start=1):
-        text = doc.get("text", "")
-        doc_id = doc.get("id", str(i))
-        parts.append(f"[Document {i} | id={doc_id}]\n{text}")
-    return "\n\n".join(parts) if parts else ""
+from fms_dgt.public.databuilders.rag.utils import render_documents
 
 
 @register_stage("lm/flow_controller/rag")
@@ -42,7 +34,7 @@ class RAGFlowControllerStage(LMFlowControllerStage):
             lines.append(f"[Scenario]\n{scenario_step.content}")
             documents = getattr(scenario_step, "documents", []) or []
             if documents:
-                doc_text = _render_documents(documents)
+                doc_text = render_documents(documents)
                 lines.append(f"\n[Documents]\n{doc_text}")
         history = steps_to_text(context.steps)
         if history:

--- a/fms_dgt/public/databuilders/rag/stages/lm_scenario_rag.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_scenario_rag.py
@@ -307,7 +307,9 @@ class RAGScenarioStage(Stage):
                 }
             )
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        outputs = self._generator(
+            generator_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         results = []
         for out, documents in zip(outputs, doc_batches):

--- a/fms_dgt/public/databuilders/rag/stages/lm_user_rag.py
+++ b/fms_dgt/public/databuilders/rag/stages/lm_user_rag.py
@@ -8,13 +8,9 @@ import json
 # Local
 from fms_dgt.core.blocks.llm.llm import LMProvider
 from fms_dgt.core.databuilders.conversation.data_objects import (
-    AssistantStep,
     ConversationDataPoint,
     FlowControllerStep,
     PersonaStep,
-    ScenarioStep,
-    ToolCallStep,
-    ToolResultStep,
     UserStep,
 )
 from fms_dgt.core.databuilders.conversation.registry import register_stage
@@ -24,92 +20,99 @@ from fms_dgt.core.databuilders.conversation.utils import (
     get_last_step_of_type,
     steps_to_messages,
 )
+from fms_dgt.public.databuilders.rag.data_objects import RAGScenarioStep
+from fms_dgt.public.databuilders.rag.utils import render_documents
 
-_USER_RAG_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "reasoning": {
-            "type": "string",
-            "description": (
-                "Step-by-step reasoning: what does the scenario need, what has already "
-                "been covered, and how should the next utterance advance the conversation?"
-            ),
-        },
-        "proposed_utterance": {
-            "type": "string",
-            "description": "Initial draft of the user's next message.",
-        },
-        "verification": {
-            "type": "string",
-            "enum": ["yes", "no"],
-            "description": (
-                "Does the proposed utterance advance the scenario without repeating "
-                "a previous question? 'yes' or 'no'."
-            ),
-        },
-        "verification_reasoning": {
-            "type": "string",
-            "description": (
-                "Explanation of the verification decision. If 'no', explain what "
-                "needs to change."
-            ),
-        },
-        "utterance": {
-            "type": "string",
-            "description": (
-                "Final user utterance. If verification is 'yes', this may be a "
-                "sharpened version of proposed_utterance. If verification is 'no', "
-                "this must be a corrected utterance that fixes the issue identified "
-                "in verification_reasoning."
-            ),
-        },
-    },
-    "required": [
-        "reasoning",
-        "proposed_utterance",
-        "verification",
-        "verification_reasoning",
-        "utterance",
-    ],
-    "additionalProperties": False,
-}
-
+# ===========================================================================
+#                       CONSTANTS
+# ===========================================================================
 _USER_RAG_RESPONSE_FORMAT = {
     "type": "json_schema",
     "json_schema": {
         "name": "rag_user_turn",
         "strict": True,
-        "schema": _USER_RAG_SCHEMA,
+        "schema": {
+            "type": "object",
+            "properties": {
+                "reasoning": {
+                    "type": "string",
+                    "description": (
+                        "Step-by-step reasoning: what does the scenario need, what has already "
+                        "been covered, and how should the next utterance advance the conversation?"
+                    ),
+                },
+                "proposed_utterance": {
+                    "type": "string",
+                    "description": "Initial draft of the user's next message.",
+                },
+                "verification": {
+                    "type": "string",
+                    "enum": ["yes", "no"],
+                    "description": (
+                        "Is the proposed utterance coherent with the scenario and conversation so far, "
+                        "without repeating a previous question? 'yes' or 'no'."
+                    ),
+                },
+                "verification_reasoning": {
+                    "type": "string",
+                    "description": (
+                        "Explanation of the verification decision. If 'no', explain what "
+                        "needs to change."
+                    ),
+                },
+                "utterance": {
+                    "type": "string",
+                    "description": (
+                        "Final user utterance. If verification is 'no', first correct the proposed "
+                        "utterance by addressing the issues in verification_reasoning. If verification "
+                        "is 'yes', start from proposed_utterance. Then rephrase as a user who is not "
+                        "familiar with the document texts, using natural language with no phrasing "
+                        "lifted from the documents."
+                    ),
+                },
+            },
+            "required": [
+                "reasoning",
+                "proposed_utterance",
+                "verification",
+                "verification_reasoning",
+                "utterance",
+            ],
+            "additionalProperties": False,
+        },
     },
 }
 
 
-def _render_documents(documents: List[dict]) -> str:
-    parts = []
-    for i, doc in enumerate(documents, start=1):
-        text = doc.get("text", "")
-        doc_id = doc.get("id", str(i))
-        parts.append(f"[Document {i} | id={doc_id}]\n{text}")
-    return "\n\n".join(parts) if parts else ""
+# ===========================================================================
+#                       HELPER METHODS
+# ===========================================================================
+def _build_input(data_point: ConversationDataPoint) -> list:
+    scenario_step = get_last_step_of_type(data_point.steps, RAGScenarioStep)
+    scenario = scenario_step.content if scenario_step else ""
+    documents = scenario_step.documents if scenario_step else []
 
+    persona_steps = [
+        step for step in data_point.steps if isinstance(step, PersonaStep) and step.target == "user"
+    ]
+    persona_text = render_persona(persona_steps[-1]) if persona_steps else ""
 
-def _build_user_rag_messages(
-    scenario: str,
-    persona_text: str,
-    pattern: str,
-    hint: str | None,
-    documents: List[dict],
-    history_steps: list,
-) -> list:
-    doc_text = _render_documents(documents)
+    fc_step = get_last_step_of_type(data_point.steps, FlowControllerStep)
+    pattern = fc_step.content if fc_step else ""
+    hint = fc_step.hint if fc_step else None
+
     system_content = (
         "You are simulating a user in a conversation with an AI assistant. "
-        "Your goal is to resolve the scenario described below by asking questions "
-        "grounded in the provided documents. Stay in character at all times.\n\n"
+        "Your goal is to advance the conversation by asking questions appropriate "
+        "to the current turn. Stay in character at all times.\n\n"
         "Rules:\n"
-        "- Ask only one focused question per turn.\n"
         "- Do not repeat a question you have already asked.\n"
-        "- Do not ask about information not present or inferable from the documents.\n"
+        "- Follow the hint faithfully. It encodes what kind of question is appropriate "
+        "for this turn. If no hint is provided, reason from the scenario and conversation "
+        "so far to determine what a natural next question would be. If neither a hint nor "
+        "a scenario is available, reason from the conversation history alone.\n"
+        "- Rephrase the final utterance as a user who is not familiar with the document "
+        "texts. Use natural language with no phrasing lifted from the documents.\n"
         "- Keep the utterance concise and natural.\n"
         "- Do not reveal that you are an AI or that you are simulating a user."
     )
@@ -121,15 +124,17 @@ def _build_user_rag_messages(
         system_content += f"\n\nInteraction pattern for this turn: {pattern}"
     if hint:
         system_content += f"\n\nHint: {hint}"
-    if doc_text:
-        system_content += f"\n\nDocuments available to ground your questions:\n{doc_text}"
+    if documents:
+        system_content += (
+            f"\n\nDocuments available to ground your questions:\n{render_documents(documents)}"
+        )
 
     messages = [{"role": "system", "content": system_content}]
 
     # Invert roles: from the simulated user's perspective, assistant turns are
     # "user" (the other side) and user turns are "assistant" (its own prior turns).
     # Tool call/result pairs are included so the model sees what was retrieved.
-    for msg in steps_to_messages(history_steps):
+    for msg in steps_to_messages(data_point.steps):
         role = msg["role"]
         if role == "user":
             messages.append({**msg, "role": "assistant"})
@@ -144,10 +149,11 @@ def _build_user_rag_messages(
         {
             "role": "user",
             "content": (
-                "Generate the next user utterance following the interaction pattern and hint. "
-                "First reason through what the scenario needs and what has already been covered. "
-                "Propose an utterance, verify it does not repeat a prior question and advances "
-                "the scenario, then produce the final utterance."
+                "Generate the next user utterance as a JSON object following the schema. "
+                "Follow the hint if provided. It tells you what kind of question to ask this turn. "
+                "Reason through what the scenario needs and what has already been covered, propose "
+                "an utterance, verify it does not repeat a prior question and is coherent with the scenario and "
+                "conversation so far, then rephrase it as a user who is not familiar with the document texts."
             ),
         }
     )
@@ -203,31 +209,9 @@ class RAGUserStage(Stage):
     ) -> List[ConversationDataPoint]:
         generator_inputs = []
         for data_point in data_points:
-            scenario_step = get_last_step_of_type(data_point.steps, ScenarioStep)
-            scenario = scenario_step.content if scenario_step else ""
-            documents = getattr(scenario_step, "documents", []) or []
-
-            persona_steps = [
-                step
-                for step in data_point.steps
-                if isinstance(step, PersonaStep) and step.target == "user"
-            ]
-            persona_text = render_persona(persona_steps[-1]) if persona_steps else ""
-
-            fc_step = get_last_step_of_type(data_point.steps, FlowControllerStep)
-            pattern = fc_step.content if fc_step else ""
-            hint = fc_step.hint if fc_step else None
-
-            history_steps = [
-                step
-                for step in data_point.steps
-                if isinstance(step, (UserStep, AssistantStep, ToolCallStep, ToolResultStep))
-            ]
             generator_inputs.append(
                 {
-                    "input": _build_user_rag_messages(
-                        scenario, persona_text, pattern, hint, documents, history_steps
-                    ),
+                    "input": _build_input(data_point),
                     "gen_kwargs": {
                         "max_new_tokens": 512,
                         "response_format": _USER_RAG_RESPONSE_FORMAT,
@@ -240,7 +224,9 @@ class RAGUserStage(Stage):
         if not generator_inputs:
             return []
 
-        outputs = self._generator(generator_inputs, method="chat_completion", disable_tqdm=True)
+        outputs = self._generator(
+            generator_inputs, method=LMProvider.CHAT_COMPLETION, disable_tqdm=True
+        )
 
         results = []
         for out in outputs:

--- a/fms_dgt/public/databuilders/rag/utils.py
+++ b/fms_dgt/public/databuilders/rag/utils.py
@@ -1,0 +1,14 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+from typing import List
+
+
+def render_documents(documents: List[dict]) -> str:
+    parts = []
+    for i, doc in enumerate(documents, start=1):
+        text = doc.get("text", "")
+        doc_id = doc.get("id", str(i))
+        parts.append(f"[Document {i} | id={doc_id}]\n{text}")
+    return "\n\n".join(parts) if parts else "(no documents provided)"

--- a/fms_dgt/public/databuilders/safety/refusal/generate.py
+++ b/fms_dgt/public/databuilders/safety/refusal/generate.py
@@ -146,7 +146,7 @@ class SafetyRefusalDataBuilder(GenerationDataBuilder):
             }
         ]
 
-        lm_outputs = self.instruction_generator(lm_inputs, method="chat_completion")
+        lm_outputs = self.instruction_generator(lm_inputs, method=LMProvider.CHAT_COMPLETION)
 
         outputs: List[SafetyRefusalData] = []
         for lm_output in lm_outputs:
@@ -231,7 +231,7 @@ class SafetyRefusalDataBuilder(GenerationDataBuilder):
             for dp in data_points
         ]
 
-        lm_outputs = self.response_generator(lm_inputs, method="chat_completion")
+        lm_outputs = self.response_generator(lm_inputs, method=LMProvider.CHAT_COMPLETION)
 
         outputs: List[SafetyRefusalData] = []
         for lm_output in lm_outputs:

--- a/tasks/public/rag/static/multi_doc2dial/dmv/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/dmv/task.yaml
@@ -117,8 +117,9 @@ iteration_stages:
         hint: >
           Identify a specific detail, term, or figure from the assistant's last
           response that appears in the documents and ask a focused question about
-          it. The follow-up must be grounded in something the documents actually
-          contain, not a tangential topic.
+          it. The follow-up must build on something established in the current
+          conversation, creating a thread that links this turn to a prior
+          exchange rather than starting a fresh topic.
 
       - name: rag/clarification
         description: >
@@ -127,12 +128,14 @@ iteration_stages:
           it said. The user is not extending the topic but questioning the
           response itself. Distinct from rag/follow_up, where the user
           understands the answer and wants to go further.
+        weight: 2.0
         hint: >
           Point to a specific part of the assistant's last answer that was
           unclear or ambiguous and ask the assistant to explain it more clearly.
           Do not use this to introduce a new topic.
 
       - name: rag/ambiguous
+        weight: 1.5
         description: >
           User poses a vague, incomplete, or keyword-style question that could
           apply to multiple aspects of the documents. The assistant should ask
@@ -145,21 +148,22 @@ iteration_stages:
 
       - name: rag/termination
         description: >
-          Select this pattern in either of two conditions: (1) the scenario has
-          been substantively resolved, meaning the user's core information need
-          is covered, no meaningful open questions remain, and continuing would
-          only produce repetition; or (2) the documents have been unable to
-          answer the last two or more questions, indicating the scenario is
-          exhausted and further turns will not produce useful information.
-          Select proactively whenever either condition is met, even if the user
-          has not explicitly said thank you or goodbye.
+          Select this pattern when ANY of the following is true: (1) the
+          scenario's stated information need is fully addressed, meaning the
+          documents have answered the specific question or task the scenario
+          set out, and any further turns would only restate or marginally
+          extend what has already been covered; (2) the documents have failed
+          to answer the last two consecutive questions, indicating the
+          available information on this thread is exhausted; (3) the
+          conversation history shows three or more distinct topics have
+          already been exchanged and no new answerable topics remain in
+          the documents. Prefer termination over continuing when in doubt.
+          An extra turn that adds little is worse than a clean close.
         hint: >
-          Generate a brief closing statement from the user that acknowledges
-          the scenario is resolved or that the available information has been
-          exhausted. This may include a thank-you, a statement of what they
-          plan to do next, or an acknowledgment that they need to look
-          elsewhere. Avoid generic phrases; make the closing reflect the
-          specific scenario.
+          Generate a brief closing statement from the user that fits the
+          specific scenario: a next step they plan to take, an acknowledgment
+          that they have what they need, or that the documents do not cover
+          what they were looking for. Do not use generic thank-you phrases.
 
   - name: lm/user/rag
     generator: generator
@@ -168,3 +172,5 @@ iteration_stages:
   # No ToolCallStep/ToolResultStep in output.
   - name: lm/assistant/rag/static
     generator: generator
+    # Retry up to 3 times when the faithfulness critic rejects a response.
+    max_retries: 3

--- a/tasks/public/rag/static/multi_doc2dial/dmv/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/dmv/task.yaml
@@ -155,9 +155,10 @@ iteration_stages:
           extend what has already been covered; (2) the documents have failed
           to answer the last two consecutive questions, indicating the
           available information on this thread is exhausted; (3) the
-          conversation history shows three or more distinct topics have
+          the Conversation History (not the Available Documents) shows three or more distinct topics have
           already been exchanged and no new answerable topics remain in
-          the documents. Prefer termination over continuing when in doubt.
+          the Available Documents. Do not count topics present only in the Available Documents as exchanged.
+          Prefer termination over continuing when in doubt.
           An extra turn that adds little is worse than a clean close.
         hint: >
           Generate a brief closing statement from the user that fits the

--- a/tasks/public/rag/static/multi_doc2dial/ssa/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/ssa/task.yaml
@@ -117,8 +117,9 @@ iteration_stages:
         hint: >
           Identify a specific detail, term, or figure from the assistant's last
           response that appears in the documents and ask a focused question about
-          it. The follow-up must be grounded in something the documents actually
-          contain, not a tangential topic.
+          it. The follow-up must build on something established in the current
+          conversation, creating a thread that links this turn to a prior
+          exchange rather than starting a fresh topic.
 
       - name: rag/clarification
         description: >
@@ -127,12 +128,14 @@ iteration_stages:
           it said. The user is not extending the topic but questioning the
           response itself. Distinct from rag/follow_up, where the user
           understands the answer and wants to go further.
+        weight: 2.0
         hint: >
           Point to a specific part of the assistant's last answer that was
           unclear or ambiguous and ask the assistant to explain it more clearly.
           Do not use this to introduce a new topic.
 
       - name: rag/ambiguous
+        weight: 1.5
         description: >
           User poses a vague, incomplete, or keyword-style question that could
           apply to multiple aspects of the documents. The assistant should ask
@@ -145,21 +148,22 @@ iteration_stages:
 
       - name: rag/termination
         description: >
-          Select this pattern in either of two conditions: (1) the scenario has
-          been substantively resolved, meaning the user's core information need
-          is covered, no meaningful open questions remain, and continuing would
-          only produce repetition; or (2) the documents have been unable to
-          answer the last two or more questions, indicating the scenario is
-          exhausted and further turns will not produce useful information.
-          Select proactively whenever either condition is met, even if the user
-          has not explicitly said thank you or goodbye.
+          Select this pattern when ANY of the following is true: (1) the
+          scenario's stated information need is fully addressed, meaning the
+          documents have answered the specific question or task the scenario
+          set out, and any further turns would only restate or marginally
+          extend what has already been covered; (2) the documents have failed
+          to answer the last two consecutive questions, indicating the
+          available information on this thread is exhausted; (3) the
+          conversation history shows three or more distinct topics have
+          already been exchanged and no new answerable topics remain in
+          the documents. Prefer termination over continuing when in doubt.
+          An extra turn that adds little is worse than a clean close.
         hint: >
-          Generate a brief closing statement from the user that acknowledges
-          the scenario is resolved or that the available information has been
-          exhausted. This may include a thank-you, a statement of what they
-          plan to do next, or an acknowledgment that they need to look
-          elsewhere. Avoid generic phrases; make the closing reflect the
-          specific scenario.
+          Generate a brief closing statement from the user that fits the
+          specific scenario: a next step they plan to take, an acknowledgment
+          that they have what they need, or that the documents do not cover
+          what they were looking for. Do not use generic thank-you phrases.
 
   - name: lm/user/rag
     generator: generator
@@ -168,3 +172,5 @@ iteration_stages:
   # No ToolCallStep/ToolResultStep in output.
   - name: lm/assistant/rag/static
     generator: generator
+    # Retry up to 3 times when the faithfulness critic rejects a response.
+    max_retries: 3

--- a/tasks/public/rag/static/multi_doc2dial/ssa/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/ssa/task.yaml
@@ -155,9 +155,10 @@ iteration_stages:
           extend what has already been covered; (2) the documents have failed
           to answer the last two consecutive questions, indicating the
           available information on this thread is exhausted; (3) the
-          conversation history shows three or more distinct topics have
+          the Conversation History (not the Available Documents) shows three or more distinct topics have
           already been exchanged and no new answerable topics remain in
-          the documents. Prefer termination over continuing when in doubt.
+          the Available Documents. Do not count topics present only in the Available Documents as exchanged.
+          Prefer termination over continuing when in doubt.
           An extra turn that adds little is worse than a clean close.
         hint: >
           Generate a brief closing statement from the user that fits the

--- a/tasks/public/rag/static/multi_doc2dial/studentaid/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/studentaid/task.yaml
@@ -117,8 +117,9 @@ iteration_stages:
         hint: >
           Identify a specific detail, term, or figure from the assistant's last
           response that appears in the documents and ask a focused question about
-          it. The follow-up must be grounded in something the documents actually
-          contain, not a tangential topic.
+          it. The follow-up must build on something established in the current
+          conversation, creating a thread that links this turn to a prior
+          exchange rather than starting a fresh topic.
 
       - name: rag/clarification
         description: >
@@ -127,12 +128,14 @@ iteration_stages:
           it said. The user is not extending the topic but questioning the
           response itself. Distinct from rag/follow_up, where the user
           understands the answer and wants to go further.
+        weight: 2.0
         hint: >
           Point to a specific part of the assistant's last answer that was
           unclear or ambiguous and ask the assistant to explain it more clearly.
           Do not use this to introduce a new topic.
 
       - name: rag/ambiguous
+        weight: 1.5
         description: >
           User poses a vague, incomplete, or keyword-style question that could
           apply to multiple aspects of the documents. The assistant should ask
@@ -145,21 +148,22 @@ iteration_stages:
 
       - name: rag/termination
         description: >
-          Select this pattern in either of two conditions: (1) the scenario has
-          been substantively resolved, meaning the user's core information need
-          is covered, no meaningful open questions remain, and continuing would
-          only produce repetition; or (2) the documents have been unable to
-          answer the last two or more questions, indicating the scenario is
-          exhausted and further turns will not produce useful information.
-          Select proactively whenever either condition is met, even if the user
-          has not explicitly said thank you or goodbye.
+          Select this pattern when ANY of the following is true: (1) the
+          scenario's stated information need is fully addressed, meaning the
+          documents have answered the specific question or task the scenario
+          set out, and any further turns would only restate or marginally
+          extend what has already been covered; (2) the documents have failed
+          to answer the last two consecutive questions, indicating the
+          available information on this thread is exhausted; (3) the
+          conversation history shows three or more distinct topics have
+          already been exchanged and no new answerable topics remain in
+          the documents. Prefer termination over continuing when in doubt.
+          An extra turn that adds little is worse than a clean close.
         hint: >
-          Generate a brief closing statement from the user that acknowledges
-          the scenario is resolved or that the available information has been
-          exhausted. This may include a thank-you, a statement of what they
-          plan to do next, or an acknowledgment that they need to look
-          elsewhere. Avoid generic phrases; make the closing reflect the
-          specific scenario.
+          Generate a brief closing statement from the user that fits the
+          specific scenario: a next step they plan to take, an acknowledgment
+          that they have what they need, or that the documents do not cover
+          what they were looking for. Do not use generic thank-you phrases.
 
   - name: lm/user/rag
     generator: generator
@@ -168,3 +172,5 @@ iteration_stages:
   # No ToolCallStep/ToolResultStep in output.
   - name: lm/assistant/rag/static
     generator: generator
+    # Retry up to 3 times when the faithfulness critic rejects a response.
+    max_retries: 3

--- a/tasks/public/rag/static/multi_doc2dial/studentaid/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/studentaid/task.yaml
@@ -155,9 +155,10 @@ iteration_stages:
           extend what has already been covered; (2) the documents have failed
           to answer the last two consecutive questions, indicating the
           available information on this thread is exhausted; (3) the
-          conversation history shows three or more distinct topics have
+          the Conversation History (not the Available Documents) shows three or more distinct topics have
           already been exchanged and no new answerable topics remain in
-          the documents. Prefer termination over continuing when in doubt.
+          the Available Documents. Do not count topics present only in the Available Documents as exchanged.
+          Prefer termination over continuing when in doubt.
           An extra turn that adds little is worse than a clean close.
         hint: >
           Generate a brief closing statement from the user that fits the

--- a/tasks/public/rag/static/multi_doc2dial/va/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/va/task.yaml
@@ -117,8 +117,9 @@ iteration_stages:
         hint: >
           Identify a specific detail, term, or figure from the assistant's last
           response that appears in the documents and ask a focused question about
-          it. The follow-up must be grounded in something the documents actually
-          contain, not a tangential topic.
+          it. The follow-up must build on something established in the current
+          conversation, creating a thread that links this turn to a prior
+          exchange rather than starting a fresh topic.
 
       - name: rag/clarification
         description: >
@@ -127,12 +128,14 @@ iteration_stages:
           it said. The user is not extending the topic but questioning the
           response itself. Distinct from rag/follow_up, where the user
           understands the answer and wants to go further.
+        weight: 2.0
         hint: >
           Point to a specific part of the assistant's last answer that was
           unclear or ambiguous and ask the assistant to explain it more clearly.
           Do not use this to introduce a new topic.
 
       - name: rag/ambiguous
+        weight: 1.5
         description: >
           User poses a vague, incomplete, or keyword-style question that could
           apply to multiple aspects of the documents. The assistant should ask
@@ -145,21 +148,22 @@ iteration_stages:
 
       - name: rag/termination
         description: >
-          Select this pattern in either of two conditions: (1) the scenario has
-          been substantively resolved, meaning the user's core information need
-          is covered, no meaningful open questions remain, and continuing would
-          only produce repetition; or (2) the documents have been unable to
-          answer the last two or more questions, indicating the scenario is
-          exhausted and further turns will not produce useful information.
-          Select proactively whenever either condition is met, even if the user
-          has not explicitly said thank you or goodbye.
+          Select this pattern when ANY of the following is true: (1) the
+          scenario's stated information need is fully addressed, meaning the
+          documents have answered the specific question or task the scenario
+          set out, and any further turns would only restate or marginally
+          extend what has already been covered; (2) the documents have failed
+          to answer the last two consecutive questions, indicating the
+          available information on this thread is exhausted; (3) the
+          conversation history shows three or more distinct topics have
+          already been exchanged and no new answerable topics remain in
+          the documents. Prefer termination over continuing when in doubt.
+          An extra turn that adds little is worse than a clean close.
         hint: >
-          Generate a brief closing statement from the user that acknowledges
-          the scenario is resolved or that the available information has been
-          exhausted. This may include a thank-you, a statement of what they
-          plan to do next, or an acknowledgment that they need to look
-          elsewhere. Avoid generic phrases; make the closing reflect the
-          specific scenario.
+          Generate a brief closing statement from the user that fits the
+          specific scenario: a next step they plan to take, an acknowledgment
+          that they have what they need, or that the documents do not cover
+          what they were looking for. Do not use generic thank-you phrases.
 
   - name: lm/user/rag
     generator: generator
@@ -168,3 +172,5 @@ iteration_stages:
   # No ToolCallStep/ToolResultStep in output.
   - name: lm/assistant/rag/static
     generator: generator
+    # Retry up to 3 times when the faithfulness critic rejects a response.
+    max_retries: 3

--- a/tasks/public/rag/static/multi_doc2dial/va/task.yaml
+++ b/tasks/public/rag/static/multi_doc2dial/va/task.yaml
@@ -155,9 +155,10 @@ iteration_stages:
           extend what has already been covered; (2) the documents have failed
           to answer the last two consecutive questions, indicating the
           available information on this thread is exhausted; (3) the
-          conversation history shows three or more distinct topics have
+          the Conversation History (not the Available Documents) shows three or more distinct topics have
           already been exchanged and no new answerable topics remain in
-          the documents. Prefer termination over continuing when in doubt.
+          the Available Documents. Do not count topics present only in the Available Documents as exchanged.
+          Prefer termination over continuing when in doubt.
           An extra turn that adds little is worse than a clean close.
         hint: >
           Generate a brief closing statement from the user that fits the

--- a/tests/base/test_concurrent_databuilder.py
+++ b/tests/base/test_concurrent_databuilder.py
@@ -125,7 +125,7 @@ class StubConcurrentBuilder(ConcurrentGenerationDataBuilder):
         return self._call_counts
 
     # Disable postprocessing and telemetry helpers that require real infrastructure.
-    def execute_postprocessing(self, tasks):
+    def execute_postprocessing(self, tasks, task_epoch=None):
         pass
 
     def _register_task_log_handler(self, task):
@@ -168,14 +168,14 @@ class TestWorkerAllocation:
     def test_single_task_gets_all_workers(self):
         task = StubTask("A", num_outputs=100)
         builder = self._builder([task], max_workers=4)
-        allocation = builder._compute_worker_allocation([task], {"A": 0})
+        allocation = builder._compute_worker_allocation([task], {"A": 0}, 4)
         assert allocation.get("A", 0) <= 4
         assert allocation.get("A", 0) >= 1
 
     def test_floor_of_one_per_task(self):
         tasks = [StubTask("A", 100), StubTask("B", 100), StubTask("C", 100)]
         builder = self._builder(tasks, max_workers=3)
-        allocation = builder._compute_worker_allocation(tasks, {"A": 0, "B": 0, "C": 0})
+        allocation = builder._compute_worker_allocation(tasks, {"A": 0, "B": 0, "C": 0}, 3)
         # Each task must get at least 1 worker when slots equal task count.
         for t in tasks:
             assert allocation.get(t.name, 0) >= 1
@@ -183,21 +183,23 @@ class TestWorkerAllocation:
     def test_total_allocation_does_not_exceed_max_workers(self):
         tasks = [StubTask("A", 1000), StubTask("B", 1000), StubTask("C", 1000)]
         builder = self._builder(tasks, max_workers=4)
-        allocation = builder._compute_worker_allocation(tasks, {"A": 0, "B": 0, "C": 0})
+        allocation = builder._compute_worker_allocation(tasks, {"A": 0, "B": 0, "C": 0}, 4)
         assert sum(allocation.values()) <= 4
 
     def test_no_new_futures_when_pool_full(self):
         tasks = [StubTask("A", 100), StubTask("B", 100)]
         builder = self._builder(tasks, max_workers=2)
         # Both slots already occupied.
-        allocation = builder._compute_worker_allocation(tasks, {"A": 1, "B": 1})
+        allocation = builder._compute_worker_allocation(tasks, {"A": 1, "B": 1}, 0)
         assert sum(allocation.values()) == 0
 
     def test_proportional_distribution_favours_larger_task(self):
         task_small = StubTask("S", num_outputs=10)
         task_large = StubTask("L", num_outputs=1000)
         builder = self._builder([task_small, task_large], max_workers=8)
-        allocation = builder._compute_worker_allocation([task_small, task_large], {"S": 0, "L": 0})
+        allocation = builder._compute_worker_allocation(
+            [task_small, task_large], {"S": 0, "L": 0}, 8
+        )
         # Large task should get more workers than small task.
         assert allocation.get("L", 0) >= allocation.get("S", 0)
 
@@ -207,7 +209,7 @@ class TestWorkerAllocation:
         # Simulate task_a nearly done: 2 remaining but already in_flight=1
         task_a.machine_data = [make_dp("A")] * 1
         builder = self._builder([task_a, task_b], max_workers=4)
-        allocation = builder._compute_worker_allocation([task_a, task_b], {"A": 1, "B": 0})
+        allocation = builder._compute_worker_allocation([task_a, task_b], {"A": 1, "B": 0}, 3)
         # task_b should absorb the free slots.
         assert allocation.get("B", 0) > 0
 
@@ -258,7 +260,7 @@ class TestConcurrentExecution:
 
         wipe_count = {"n": 0}
 
-        def postprocessing_that_wipes_once(tasks):
+        def postprocessing_that_wipes_once(tasks, task_epoch=None):
             if wipe_count["n"] == 0:
                 for t in tasks:
                     t.machine_data.clear()

--- a/tests/core/blocks/llm/test_llm.py
+++ b/tests/core/blocks/llm/test_llm.py
@@ -191,30 +191,35 @@ def lm_caching_test(model_cfg):
 # ===========================================================================
 
 
+@pytest.mark.live
 @pytest.mark.skipif(SKIP_VLLM, reason='requires "vllm" library')
 @pytest.mark.parametrize("model_cfg", [LM_VLLM_CFG])
 def test_generate(model_cfg):
     execute_completion_flow(model_cfg)
 
 
+@pytest.mark.live
 @pytest.mark.skipif(SKIP_VLLM, reason='requires "vllm" library')
 @pytest.mark.parametrize("model_cfg", [LM_VLLM_CFG])
 def test_chat(model_cfg):
     execute_chat_completion_flow(model_cfg)
 
 
+@pytest.mark.live
 @pytest.mark.skipif(SKIP_VLLM, reason='requires "vllm" library')
 @pytest.mark.parametrize("model_cfg", [LM_VLLM_SERVER_CFG])
 def test_lm_caching(model_cfg):
     lm_caching_test(model_cfg)
 
 
+@pytest.mark.live
 @pytest.mark.skipif(SKIP_VLLM, reason='requires "vllm" library')
 @pytest.mark.parametrize("model_cfg", [LM_VLLM_SERVER_CFG])
 def test_auto_chat_template(model_cfg):
     auto_chat_template_test(model_cfg)
 
 
+@pytest.mark.live
 @pytest.mark.skipif(SKIP_VLLM, reason='requires "vllm" library')
 def test_vllm_tensor_parallel():
     """

--- a/tests/core/databuilders/test_conversation.py
+++ b/tests/core/databuilders/test_conversation.py
@@ -54,8 +54,10 @@ def _make_task(
     task._min_turns = min_turns
     task._initialization_stage_configs = init_stages or []
     task._iteration_stage_configs = iter_stages or []
+    task._termination_stage_configs = []
     task.initialization_stages = []
     task.iteration_stages = []
+    task.termination_stages = []
 
     # Attributes expected by ConversationDataBuilder (name + sample_examples).
     # `name` is a read-only property backed by `_name`.
@@ -205,15 +207,20 @@ class TestRunSingleConversation:
         # terminated at turn 1 which is < min_turns=2
         assert results == []
 
-    def test_early_terminate_at_min_turns_returns_context(self):
+    def test_early_terminate_at_min_turns_drops_context(self):
+        # min_turns is enforced against fully-completed turns (turn_count is
+        # incremented only after all iteration stages run for a turn). A
+        # flow-controller terminate fired during turn 1, before any iteration
+        # has completed, means 0 turns are counted — so min_turns=1 is not
+        # met and the context is dropped. This conservative check works
+        # correctly regardless of where the flow controller sits in the
+        # iteration stage list.
         task = _make_task(max_turns=5, min_turns=1)
         task.initialization_stages = []
         task.iteration_stages = [_make_terminate_stage("terminator")]
 
         results = self._run(task)
-        assert len(results) == 1
-        fc_steps = [step for step in results[0].steps if step.role == "flow_controller"]
-        assert fc_steps and fc_steps[-1].terminate is True
+        assert results == []
 
     def test_max_turns_caps_iteration(self):
         task = _make_task(max_turns=3, min_turns=1)

--- a/tests/core/tools/engines/helpers.py
+++ b/tests/core/tools/engines/helpers.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import json
 
 # Local
-from fms_dgt.core.tools.constants import TOOL_NAMESPACE_SEP
 from fms_dgt.core.tools.data_objects import Tool, ToolCall
 from fms_dgt.core.tools.engines import LMToolEngine
 from fms_dgt.core.tools.registry import ToolRegistry
@@ -37,7 +36,8 @@ def _make_call(
     call_id: str | None = None,
 ) -> ToolCall:
     return ToolCall(
-        name=f"{namespace}{TOOL_NAMESPACE_SEP}{tool}",
+        name=tool,
+        namespace=namespace,
         arguments={"q": "hello"},
         call_id=call_id,
     )

--- a/tests/core/tools/engines/search/test_file_and_samplers.py
+++ b/tests/core/tools/engines/search/test_file_and_samplers.py
@@ -50,7 +50,7 @@ def _make_engine(path: str, **kwargs) -> FileSearchEngine:
 
 def _tc(call_id: str = "c1", size: int | None = None) -> ToolCall:
     args = {} if size is None else {"size": size}
-    return ToolCall(name="ns::search", arguments=args, call_id=call_id)
+    return ToolCall(name="search", namespace="ns", arguments=args, call_id=call_id)
 
 
 # ---------------------------------------------------------------------------
@@ -168,10 +168,10 @@ class TestFileSearchEngineResults:
         engine = _make_engine(_CORPUS_CANONICAL)
         engine.setup("s1")
         try:
-            tc = ToolCall(name="ns::search", arguments={}, call_id="my-call-id")
+            tc = ToolCall(name="search", namespace="ns", arguments={}, call_id="my-call-id")
             [result] = engine.execute("s1", [tc])
             assert result.call_id == "my-call-id"
-            assert result.name == "ns::search"
+            assert result.name == "search"
         finally:
             engine.teardown("s1")
 
@@ -292,7 +292,7 @@ class TestFileSearchEngineErrorInjection:
             assert result.error == "timeout"
             assert result.result is None
             assert result.call_id == "ce"
-            assert result.name == "ns::search"
+            assert result.name == "search"
         finally:
             engine.teardown("s1")
 

--- a/tests/core/tools/engines/search/test_web.py
+++ b/tests/core/tools/engines/search/test_web.py
@@ -29,6 +29,14 @@ from fms_dgt.core.tools.engines.search.web.utils import (
 )
 from fms_dgt.core.tools.registry import ToolRegistry
 
+SKIP_SEARCH = False
+try:
+    # Third Party
+    from ddgs import DDGS  # noqa: F401
+    import trafilatura  # noqa: F401
+except ModuleNotFoundError:
+    SKIP_SEARCH = True
+
 # ---------------------------------------------------------------------------
 # Minimal HTML pages used across tests — no network needed
 # ---------------------------------------------------------------------------
@@ -109,6 +117,9 @@ class TestValidateContent:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    SKIP_SEARCH, reason="requires search extras — install with: pip install fms_dgt[search]"
+)
 class TestExtractText:
     def test_extracts_article_content(self):
         text = extract_text(_SIMPLE_HTML)
@@ -170,6 +181,9 @@ class TestBuildDocumentSnippetOnly:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    SKIP_SEARCH, reason="requires search extras — install with: pip install fms_dgt[search]"
+)
 class TestBuildDocumentWithFetch:
     def test_raw_content_stored_in_metadata(self):
         with patch(
@@ -311,6 +325,9 @@ _DDG_RAW_RESULTS = [
 ]
 
 
+@pytest.mark.skipif(
+    SKIP_SEARCH, reason="requires search extras — install with: pip install fms_dgt[search]"
+)
 class TestDuckDuckGoEngineExecute:
     def _run(self, engine, tc):
         engine.setup("s1")

--- a/tests/core/tools/engines/search/test_web.py
+++ b/tests/core/tools/engines/search/test_web.py
@@ -86,7 +86,7 @@ def _make_ddg_engine(**kwargs) -> DuckDuckGoSearchEngine:
 
 def _tc(query: str = "mount rushmore faces", call_id: str = "c1", **extra) -> ToolCall:
     args = {"query": query, **extra}
-    return ToolCall(name="ns::search", arguments=args, call_id=call_id)
+    return ToolCall(name="search", namespace="ns", arguments=args, call_id=call_id)
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +384,7 @@ class TestDuckDuckGoEngineExecute:
         engine = _make_ddg_engine()
         engine._ddgs = self._mock_ddgs()
         [result] = self._run(
-            engine, ToolCall(name="ns::search", arguments={"query": ""}, call_id="c0")
+            engine, ToolCall(name="search", namespace="ns", arguments={"query": ""}, call_id="c0")
         )
         assert result.result == []
 
@@ -393,7 +393,7 @@ class TestDuckDuckGoEngineExecute:
         engine._ddgs = self._mock_ddgs()
         [result] = self._run(engine, _tc(call_id="my-id"))
         assert result.call_id == "my-id"
-        assert result.name == "ns::search"
+        assert result.name == "search"
 
     def test_ddg_exception_raises_runtime_error(self):
         # Third Party

--- a/tests/core/tools/engines/test_lm.py
+++ b/tests/core/tools/engines/test_lm.py
@@ -171,8 +171,8 @@ class TestLMToolEngineSimulateVsExecute:
         history_b = eng.get_session_state("branch_b")["tool_executions"]
         assert len(history_a) == 2
         assert len(history_b) == 2
-        assert history_a[1]["tool_call"]["id"] == "ca"
-        assert history_b[1]["tool_call"]["id"] == "cb"
+        assert history_a[1]["tool_call"].call_id == "ca"
+        assert history_b[1]["tool_call"].call_id == "cb"
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +184,7 @@ class TestLMToolEngineUnknownTool:
     def test_unknown_tool_returns_error_result(self):
         eng = _make_lm_engine()
         eng.setup("s1")
-        call = ToolCall(name="ns::nonexistent_tool", arguments={})
+        call = ToolCall(name="nonexistent_tool", namespace="ns", arguments={})
         results = eng.execute("s1", [call])
         assert results[0].is_error
         assert "Unknown tool" in results[0].error
@@ -252,7 +252,7 @@ class TestLMToolEngineNamespaceScoping:
         reg = _make_registry("weather_api")
         eng = _make_lm_engine(reg, namespaces=["hr_api"])
         eng.setup("s1")
-        call = ToolCall(name="weather_api::search", arguments={})
+        call = ToolCall(name="search", namespace="weather_api", arguments={})
         results = eng.execute("s1", [call])
         assert results[0].is_error
         assert "Unknown tool" in results[0].error
@@ -262,7 +262,7 @@ class TestLMToolEngineNamespaceScoping:
         eng = _make_lm_engine(reg, namespaces=None)
         _set_lm_response(eng, {"result": "sunny"})
         eng.setup("s1")
-        call = ToolCall(name="weather_api::search", arguments={"q": "hello"})
+        call = ToolCall(name="search", namespace="weather_api", arguments={"q": "hello"})
         results = eng.execute("s1", [call])
         assert not results[0].is_error
 

--- a/tests/core/tools/engines/test_mcp.py
+++ b/tests/core/tools/engines/test_mcp.py
@@ -20,7 +20,6 @@ import time
 import pytest
 
 # Local
-from fms_dgt.core.tools.constants import TOOL_NAMESPACE_SEP
 from fms_dgt.core.tools.data_objects import ToolCall
 from fms_dgt.core.tools.engines.mcp import MCPToolEngine
 from fms_dgt.core.tools.loaders.mcp import MCPToolLoader
@@ -71,7 +70,7 @@ def engine(registry):
 
 
 def _call(tool: str, **kwargs) -> ToolCall:
-    return ToolCall(name=f"{_NS}{TOOL_NAMESPACE_SEP}{tool}", arguments=kwargs)
+    return ToolCall(name=tool, namespace=_NS, arguments=kwargs)
 
 
 # ===========================================================================
@@ -166,7 +165,7 @@ class TestMCPToolEngine:
         assert r.result[0]["text"] == "hello mcp"
 
     def test_unknown_tool_returns_error(self, engine):
-        call = ToolCall(name=f"{_NS}{TOOL_NAMESPACE_SEP}nonexistent", arguments={})
+        call = ToolCall(name="nonexistent", namespace=_NS, arguments={})
         results = engine.execute(self._SESSION, [call])
         assert results[0].is_error
         assert "nonexistent" in results[0].error

--- a/tests/core/tools/engines/test_rest.py
+++ b/tests/core/tools/engines/test_rest.py
@@ -22,7 +22,6 @@ from typing import Any, Dict
 import pytest
 
 # Local
-from fms_dgt.core.tools.constants import TOOL_NAMESPACE_SEP
 from fms_dgt.core.tools.data_objects import ToolCall
 from fms_dgt.core.tools.engines.rest import RESTToolEngine
 from fms_dgt.core.tools.loaders.rest import (
@@ -113,7 +112,7 @@ def _registry_from_inline(operation_ids=None) -> ToolRegistry:
 
 
 def _call(tool: str, **kwargs) -> ToolCall:
-    return ToolCall(name=f"{_NS}{TOOL_NAMESPACE_SEP}{tool}", arguments=kwargs)
+    return ToolCall(name=tool, namespace=_NS, arguments=kwargs)
 
 
 # ===========================================================================
@@ -159,7 +158,7 @@ class TestRESTToolLoaderUnit:
         engine = RESTToolEngine(registry)
         engine.setup("s1")
         try:
-            call = ToolCall(name=f"{_NS}{TOOL_NAMESPACE_SEP}missing", arguments={})
+            call = ToolCall(name="missing", namespace=_NS, arguments={})
             results = engine.execute("s1", [call])
             assert results[0].is_error
             assert "missing" in results[0].error

--- a/tests/core/tools/enrichments/test_neighbors.py
+++ b/tests/core/tools/enrichments/test_neighbors.py
@@ -53,6 +53,7 @@ def _make_enrichment() -> NeighborsEnrichment:
     enrichment._model_name = "mock-model"
     enrichment._max_candidates = 50
     enrichment._max_neighbors = 10
+    enrichment._duplicate_sim_thresh = 0.9
     enrichment._force = True
 
     mock_model = MagicMock()
@@ -86,7 +87,10 @@ class TestNeighborsEnrichment:
         assert len(reg.artifacts[NeighborsEnrichment.artifact_key]) == 3
 
     def test_artifact_structure(self):
-        """Artifact shape: {qname: {schema_fp: {ns: [(name, fp, score)]}}}."""
+        """Artifact shape: {qname: {schema_fp: {ns: (neighbors, duplicates)}}}.
+
+        Each of ``neighbors`` and ``duplicates`` is a list of (name, fp, score).
+        """
         t1 = _tool("alpha", ns="api")
         t2 = _tool("beta", ns="api")
         reg = _registry(t1, t2)
@@ -97,12 +101,14 @@ class TestNeighborsEnrichment:
             assert "::" in src_qname
             for src_fp, ns_buckets in fp_map.items():
                 assert isinstance(src_fp, str)
-                for ns, triples in ns_buckets.items():
+                for ns, bucket in ns_buckets.items():
                     assert isinstance(ns, str)
-                    for name, tgt_fp, score in triples:
-                        assert "::" not in name  # unqualified
-                        assert isinstance(tgt_fp, str)
-                        assert isinstance(score, float)
+                    neighbors_triples, duplicates_triples = bucket
+                    for triples in (neighbors_triples, duplicates_triples):
+                        for name, tgt_fp, score in triples:
+                            assert "::" not in name  # unqualified
+                            assert isinstance(tgt_fp, str)
+                            assert isinstance(score, float)
 
     def test_self_not_in_neighbors(self):
         tools = [_tool(f"t{i}") for i in range(4)]
@@ -113,7 +119,9 @@ class TestNeighborsEnrichment:
         for src_qname, fp_map in neighbors.items():
             src_name = src_qname.split("::", 1)[1]
             for ns_buckets in fp_map.values():
-                all_names = [n for triples in ns_buckets.values() for n, _, _ in triples]
+                all_names = [
+                    n for bucket in ns_buckets.values() for triples in bucket for n, _, _ in triples
+                ]
                 assert src_name not in all_names
 
     def test_neighbor_scores_are_floats(self):
@@ -124,9 +132,10 @@ class TestNeighborsEnrichment:
         neighbors = reg.artifacts[NeighborsEnrichment.artifact_key]
         for fp_map in neighbors.values():
             for ns_buckets in fp_map.values():
-                for triples in ns_buckets.values():
-                    for _, _, score in triples:
-                        assert isinstance(score, float)
+                for bucket in ns_buckets.values():
+                    for triples in bucket:
+                        for _, _, score in triples:
+                            assert isinstance(score, float)
 
     def test_empty_registry(self):
         reg = _registry()
@@ -145,8 +154,9 @@ class TestNeighborsEnrichment:
         neighbors = reg.artifacts[NeighborsEnrichment.artifact_key]
         for fp_map in neighbors.values():
             for ns_buckets in fp_map.values():
-                for triples in ns_buckets.values():
-                    assert len(triples) <= 1
+                for bucket in ns_buckets.values():
+                    neighbors_triples, _ = bucket
+                    assert len(neighbors_triples) <= 1
 
     def test_namespace_bucketing(self):
         """Tools from different namespaces appear in separate buckets."""
@@ -161,9 +171,11 @@ class TestNeighborsEnrichment:
         src_buckets = neighbors[t1.qualified_name][fp]
         assert "ns_a" in src_buckets
         assert "ns_b" in src_buckets
-        for name, _, _ in src_buckets["ns_a"]:
+        ns_a_neighbors, _ = src_buckets["ns_a"]
+        ns_b_neighbors, _ = src_buckets["ns_b"]
+        for name, _, _ in ns_a_neighbors:
             assert name == "t2"
-        for name, _, _ in src_buckets["ns_b"]:
+        for name, _, _ in ns_b_neighbors:
             assert name == "t3"
 
     def test_overloads_get_separate_entries(self):

--- a/tests/core/tools/samplers/test_neighbor.py
+++ b/tests/core/tools/samplers/test_neighbor.py
@@ -59,14 +59,19 @@ def _make_neighbors_artifact(
     source: Tool,
     targets: list,  # list of (Tool, score)
 ) -> dict:
-    """Build a minimal neighbors artifact for a single source tool."""
+    """Build a minimal neighbors artifact for a single source tool.
+
+    Artifact shape (per enrichment):
+      {src_qname: {src_fp: {ns: (neighbors_triples, duplicates_triples)}}}
+    Each triple is (unqualified_name, tgt_fp, score).
+    """
     src_fp = _fp(source)
     ns_buckets: dict = {}
     for tgt, score in targets:
         ns = tgt.namespace
         if ns not in ns_buckets:
-            ns_buckets[ns] = []
-        ns_buckets[ns].append((tgt.name, _fp(tgt), score))
+            ns_buckets[ns] = ([], [])
+        ns_buckets[ns][0].append((tgt.name, _fp(tgt), score))
     return {source.qualified_name: {src_fp: ns_buckets}}
 
 
@@ -147,13 +152,6 @@ class TestNeighborSamplerBasic:
             result = sampler.sample()
         assert len(result) == 3
 
-    def test_seed_is_first(self):
-        reg, seed, _ = _simple_setup()
-        sampler = NeighborToolSampler(registry=reg, k=2, namespace="ns")
-        with patch.object(sampler, "_select_seed", return_value=seed):
-            result = sampler.sample()
-        assert result[0] is seed
-
     def test_no_duplicates(self):
         reg, seed, _ = _simple_setup()
         sampler = NeighborToolSampler(registry=reg, k=4, namespace="ns")
@@ -232,10 +230,13 @@ class TestNeighborSamplerCapping:
         reg.artifacts["neighbors"] = {
             seed.qualified_name: {
                 src_fp: {
-                    "ns": [
-                        ("real", _fp(real_neighbor), 0.9),
-                        ("ghost", stale_fp, 0.8),
-                    ]
+                    "ns": (
+                        [
+                            ("real", _fp(real_neighbor), 0.9),
+                            ("ghost", stale_fp, 0.8),
+                        ],
+                        [],
+                    )
                 }
             }
         }
@@ -311,7 +312,8 @@ class TestNeighborScoreWeighting:
         with patch.object(sampler, "_select_seed", return_value=seed):
             for _ in range(200):
                 result = sampler.sample()
-                counts[result[1].name] += 1
+                for tool in result:
+                    counts[tool.name] += 1
         total = sum(counts.values())
         for name in counts:
             assert counts[name] / total > 0.1
@@ -328,7 +330,8 @@ class TestNeighborScoreWeighting:
         with patch.object(sampler, "_select_seed", return_value=seed):
             for _ in range(200):
                 result = sampler.sample()
-                counts[result[1].name] += 1
+                for tool in result:
+                    counts[tool.name] += 1
         assert counts["hi"] > counts["lo"]
 
     def test_low_temperature_concentrates_on_top_neighbor(self):
@@ -342,8 +345,9 @@ class TestNeighborScoreWeighting:
         with patch.object(sampler, "_select_seed", return_value=seed):
             for _ in range(100):
                 result = sampler.sample()
-                counts[result[1].name] += 1
-        # At very low temperature, hi should dominate almost entirely.
+                for tool in result:
+                    counts[tool.name] += 1
+        # At very low temperature, hi should be sampled nearly every run.
         assert counts["hi"] > 90
 
     def test_invalid_temperature_raises(self):

--- a/tests/core/tools/test_registry.py
+++ b/tests/core/tools/test_registry.py
@@ -234,13 +234,13 @@ class TestMatch:
 
     def test_unknown_tool_returns_none(self):
         reg = ToolRegistry()
-        tc = ToolCall(name="ns::unknown", arguments={})
+        tc = ToolCall(name="unknown", namespace="ns", arguments={})
         assert reg.match(tc) is None
 
     def test_single_overload_returned_immediately(self):
         tool = self._make_overload("search", ["query", "limit"])
         reg = ToolRegistry(tools=[tool])
-        tc = ToolCall(name="ns::search", arguments={"query": "cats"})
+        tc = ToolCall(name="search", namespace="ns", arguments={"query": "cats"})
         assert reg.match(tc) is tool
 
     def test_multiple_overloads_validated_by_schema(self):
@@ -251,7 +251,9 @@ class TestMatch:
         reg = ToolRegistry(tools=[tool_a, tool_b])
 
         # Call supplies "filter" — only B is valid
-        tc = ToolCall(name="ns::search", arguments={"query": "cats", "filter": "recent"})
+        tc = ToolCall(
+            name="search", namespace="ns", arguments={"query": "cats", "filter": "recent"}
+        )
         assert reg.match(tc) is tool_b
 
     def test_multiple_overloads_required_field_disambiguates(self):
@@ -262,7 +264,7 @@ class TestMatch:
         reg = ToolRegistry(tools=[tool_a, tool_b])
 
         # Call only supplies "query" — B fails validation (missing required "filter"), A passes
-        tc = ToolCall(name="ns::search", arguments={"query": "cats"})
+        tc = ToolCall(name="search", namespace="ns", arguments={"query": "cats"})
         assert reg.match(tc) is tool_a
 
     def test_tiebreaker_uses_key_overlap(self):
@@ -274,11 +276,13 @@ class TestMatch:
         reg = ToolRegistry(tools=[tool_a, tool_b])
 
         # Call has "query" and "filter" — overlaps B more (2 vs 1)
-        tc = ToolCall(name="ns::search", arguments={"query": "cats", "filter": "recent"})
+        tc = ToolCall(
+            name="search", namespace="ns", arguments={"query": "cats", "filter": "recent"}
+        )
         assert reg.match(tc) is tool_b
 
         # Call has "query" and "limit" — overlaps A more
-        tc2 = ToolCall(name="ns::search", arguments={"query": "cats", "limit": "10"})
+        tc2 = ToolCall(name="search", namespace="ns", arguments={"query": "cats", "limit": "10"})
         assert reg.match(tc2) is tool_a
 
     def test_no_valid_overload_falls_back_to_key_overlap(self):
@@ -289,7 +293,9 @@ class TestMatch:
 
         # Call supplies only "query" and "filter" — neither strictly validates,
         # but B has higher key overlap.
-        tc = ToolCall(name="ns::search", arguments={"query": "cats", "filter": "recent"})
+        tc = ToolCall(
+            name="search", namespace="ns", arguments={"query": "cats", "filter": "recent"}
+        )
         assert reg.match(tc) is tool_b
 
     def test_namespaces_filter_restricts_candidates(self):
@@ -297,8 +303,8 @@ class TestMatch:
         tool_b = Tool(name="search", namespace="hr_api", parameters={})
         reg = ToolRegistry(tools=[tool_a, tool_b])
 
-        tc_weather = ToolCall(name="weather_api::search", arguments={})
-        tc_hr = ToolCall(name="hr_api::search", arguments={})
+        tc_weather = ToolCall(name="search", namespace="weather_api", arguments={})
+        tc_hr = ToolCall(name="search", namespace="hr_api", arguments={})
 
         # Scoped to weather_api only — hr call returns None
         assert reg.match(tc_weather, namespaces=["weather_api"]) is tool_a
@@ -313,7 +319,7 @@ class TestMatch:
         tool_b = Tool(name="search", namespace="hr_api", parameters={})
         reg = ToolRegistry(tools=[tool_a, tool_b])
 
-        tc = ToolCall(name="weather_api::search", arguments={})
+        tc = ToolCall(name="search", namespace="weather_api", arguments={})
         assert reg.match(tc, namespaces=None) is tool_a
 
 

--- a/tests/public/rag/test_rag.py
+++ b/tests/public/rag/test_rag.py
@@ -56,11 +56,26 @@ def _docs(*texts: str) -> List[Document]:
 
 
 def _mock_generator(response: str) -> MagicMock:
-    """Return a mock LMProvider that always replies with ``response``."""
+    """Return a mock LMProvider that always replies with ``response``.
+
+    When called with a response_format in gen_kwargs (critique calls), returns
+    a JSON-encoded ``{"valid": "yes", "issues": "", "reasoning": "ok"}`` so
+    that the critique always approves the generated response. Generation calls
+    (no response_format) return ``response`` verbatim.
+    """
+    _critique_ok = '{"valid": "yes", "issues": "", "reasoning": "ok"}'
+
+    def _side_effect(inputs, **kw):
+        results = []
+        for inp in inputs:
+            rf = (inp.get("gen_kwargs") or {}).get("response_format") or {}
+            is_critique = rf.get("json_schema", {}).get("name") == "rag_critique"
+            content = _critique_ok if is_critique else response
+            results.append({**inp, "result": {"content": content}})
+        return results
+
     gen = MagicMock()
-    gen.side_effect = lambda inputs, **kw: [
-        {"result": {"content": response}, "reference": inp["reference"]} for inp in inputs
-    ]
+    gen.side_effect = _side_effect
     return gen
 
 

--- a/tests/public/rag/test_rag.py
+++ b/tests/public/rag/test_rag.py
@@ -476,13 +476,12 @@ class TestLiveRetrievalAssistantStage:
     ):
         """Build a generator mock that returns a tool call on call #1, plain text on call #2."""
         call_count = [0]
-        qualified = f"{namespace}::{tool_name}"
 
         def side_effect(inputs, **kw):
             call_count[0] += 1
             if call_count[0] == 1:
                 return [
-                    {"result": _tool_call_result(qualified, query), "reference": inp["reference"]}
+                    {"result": _tool_call_result(tool_name, query), "reference": inp["reference"]}
                     for inp in inputs
                 ]
             return [
@@ -542,7 +541,7 @@ class TestLiveRetrievalAssistantStage:
         results = stage([self._ctx_with_user_turn()])
 
         tool_call_step = [step for step in results[0].steps if step.role == "tool_call"][-1]
-        assert tool_call_step.content["name"] == "custom::my_retriever"
+        assert tool_call_step.content["name"] == "my_retriever"
 
     def test_retrieval_result_stored_in_tool_result_step(self):
         docs = _docs("Quantum computers use superposition.")

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ requires-dist = [
     { name = "anthropic" },
     { name = "datasets" },
     { name = "ddgs", marker = "extra == 'search'", specifier = ">=9.0" },
-    { name = "elasticsearch", marker = "extra == 'search'", specifier = ">=8.0,<9" },
+    { name = "elasticsearch", marker = "extra == 'search'", specifier = ">=8.0" },
     { name = "faiss-cpu" },
     { name = "fastapi" },
     { name = "fastparquet", marker = "extra == 'time-series'", specifier = ">=2024.5.0" },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

- **`ConcurrentGenerationDataBuilder` — flat per-task state machine.** The
  previous implementation used a two-level epoch loop where all tasks generated                                                                            
  in lockstep, then postprocessing ran as a blocking synchronous phase. This PR                                                                            
  replaces that with a flat event loop where each task progresses independently                                                                            
  through `GENERATING → DRAINING → PENDING_POSTPROC → IN_POSTPROC`.                                                                                        
  Postprocessing now runs as futures in the shared `ThreadPoolExecutor` instead                                                                            
  of blocking generation. Worker allocation is priority-based: postproc slots                                                                              
  are reserved first, then remaining slots are distributed proportionally                                                                                  
  across generation tasks. `_spawn_futures` is renamed to                                                                                                  
  `_allocate_and_spawn`, and `execute_postprocessing` / `_write_postprocessing`                                                                            
  now take a `task_epoch` parameter so per-task epoch counters propagate                                                                                   
  correctly.                                                                                                                                               
                                                                                                                                                           
- **RAG stage refinements.** Prompt sections in the RAG conversation stages                                                                                
  are relabeled to `[Available Documents]` / `[Conversation History]`, with an
  explicit placeholder when history is empty. `multi_doc2dial` task configs                                                                                
  (`dmv`, `ssa`, `studentaid`, `va`) are updated so termination criteria                                                                                   
  distinguish topic counts in Conversation History from those only in                                                                                      
  Available Documents. Shared helpers move into `rag/utils.py`.                                                                                            
                                                                                                                                                           
- **Thread safety.** `RougeDedupValidator._cache` now takes a `threading.Lock`                                                                             
  to guard concurrent tokenization writes, which is required now that                                                                                      
  postprocessing runs concurrently with generation.                                                                                                        
                                                                                                                                                           
- **Tests and misc.** vLLM tests are marked `@pytest.mark.live`; search tests                                                                              
  are guarded behind optional-dependency skipif; the mock generator handles                                                                                
  critique calls; elasticsearch constraint relaxed to `>=8.0`.                                                                                             
                                                                                                                                                           
## Special notes for your reviewer                                                                                                                       
                                                                                                                                                           
- The concurrent databuilder is the bulk of the diff (~580 lines in                                                                                        
  `fms_dgt/base/databuilder/concurrent.py`). The state machine and worker
  allocation logic is the part that benefits from careful review — the                                                                                     
  per-task epoch plumbing through `execute_postprocessing` in particular.                                                                                  
                                                                                                                                                           
- The RAG prompt relabeling touches four `multi_doc2dial` task YAMLs in                                                                                    
  parallel; the changes are mechanical but worth a sanity check against the                                                                                
  new `[Conversation History]` vs. `[Available Documents]` distinction in the                                                                              
  termination criteria.                                                                                                                                    
                                                                                                                                                           
## If applicable**                                                                                                                                       
  - [ ] this PR contains documentation
  - [x] this PR contains unit tests                                                                                                                        
  - [x] this PR has been tested for backwards compatibility