### PR TITLE
feat(block,utils): nested DSL in input_map/output_map

### DIFF
--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -3,7 +3,7 @@
 
 # Standard
 from abc import abstractmethod
-from dataclasses import asdict, is_dataclass
+from dataclasses import MISSING, asdict, is_dataclass
 from typing import Any, Dict, Iterable, List, Tuple
 import asyncio
 import dataclasses
@@ -30,6 +30,10 @@ from fms_dgt.constants import (
     TASK_NAME_KEY,
     TYPE_KEY,
 )
+from fms_dgt.utils import from_dataclass as _from_dataclass
+from fms_dgt.utils import from_dict as _from_dict
+from fms_dgt.utils import to_dataclass as _to_dataclass
+from fms_dgt.utils import to_dict as _to_dict
 
 # ===========================================================================
 #                       CONSTATNTS
@@ -333,11 +337,22 @@ class Block:
 
             args = (self._req_args + self._opt_args) or data_type_map.keys()
 
-            mapped_data = {
-                arg: inp_obj.get(data_type_map.get(arg))
-                for arg in args
-                if data_type_map.get(arg) in inp_obj
-            }
+            # Read each mapped arg via the nested DSL. Skip the arg entirely
+            # when its path is absent (no mapping) or the terminal segment is
+            # missing on the row — the dataclass constructor's declared default
+            # then applies. Intermediate-segment misses on nested paths still
+            # raise (by contract of ``from_dict``): those are config errors
+            # where the user asserted a shape the row does not satisfy.
+            # ``None`` at the terminal is a real value and flows through.
+            mapped_data = {}
+            for arg in args:
+                path = data_type_map.get(arg)
+                if path is None:
+                    continue
+                value = _from_dict(inp_obj, path, strict=False)
+                if value is MISSING:
+                    continue
+                mapped_data[arg] = value
 
             missing = [r_a for r_a in self._req_args if r_a not in mapped_data]
             if missing:
@@ -375,16 +390,32 @@ class Block:
         output_map = {**self._get_default_map(src_data), **output_map}
 
         if is_dataclass(src_data):
-            for k, v in output_map.items():
-                # since a dataclass will throw an error, only try to add attributes if original data type has them
-                if hasattr(src_data, v):
-                    attr_val = inp[k] if isinstance(inp, dict) else getattr(inp, k)
-                    setattr(src_data, v, attr_val)
+            for k, path in output_map.items():
+                # Read the block's output value. When ``inp`` is a dict (DATA_TYPE=None
+                # blocks), the DSL on ``k`` lets callers pull nested values out of the
+                # block's returned dict. When ``inp`` is a dataclass, ``k`` is a
+                # declared field name by construction of the dataclass schema, so the
+                # dataclass walker covers the rare nested-dataclass-field case.
+                if isinstance(inp, dict):
+                    attr_val = _from_dict(inp, k)
+                else:
+                    attr_val = _from_dataclass(inp, k)
+                _to_dataclass(src_data, path, attr_val)
         elif isinstance(src_data, (dict, pd.DataFrame, Dataset)):
-            # TODO: handle things other than dictionaries
-            for k, v in output_map.items():
-                attr_val = inp[k] if isinstance(inp, dict) else getattr(inp, k)
-                src_data[v] = attr_val
+            # TODO: handle things other than dictionaries (pd.DataFrame / Dataset
+            # rows are dicts by the time they reach here; full DataFrame / Dataset
+            # objects in this branch are likely dead — audit tracked in design doc
+            # item 5 before removing the type from this isinstance tuple).
+            for k, path in output_map.items():
+                # Reads on `inp` use the DSL when `inp` is a dict (DATA_TYPE=None
+                # blocks returning nested dicts benefit from this). When `inp` is
+                # a dataclass, `k` is a flat field name by construction of the
+                # dataclass schema; `getattr` is the correct accessor.
+                if isinstance(inp, dict):
+                    attr_val = _from_dict(inp, k)
+                else:
+                    attr_val = getattr(inp, k)
+                _to_dict(src_data, path, attr_val)
         else:
             raise TypeError(f"Unexpected input type: {type(inp)}")
 

--- a/fms_dgt/utils.py
+++ b/fms_dgt/utils.py
@@ -3,6 +3,9 @@
 
 # Standard
 from collections import ChainMap
+from dataclasses import MISSING
+from dataclasses import fields as _dc_fields
+from dataclasses import is_dataclass
 from json import JSONDecodeError
 from typing import (
     Any,
@@ -858,153 +861,502 @@ def convert_byte_size(size_bytes):
 # ===========================================================================
 #                       DICTIONARY PROCESSOR
 # ===========================================================================
-def from_dict(dictionary: Dict[str, Any], key: str):
-    """
-    Fetching value for key from the dictionary.
+# Path DSL used by ``from_dict`` / ``to_dict``:
+#
+#   ``a.b``           — plain key traversal.
+#   ``a[0]``          — integer index into a list.
+#   ``a[:n]`` / ``a[n:]`` — slice (read-only; ``to_dict`` rejects).
+#   ``a[+]``          — append (``to_dict`` only; ``from_dict`` rejects).
+#
+# Missing-key semantics on reads: intermediate segments always raise
+# ``KeyError``; the terminal segment raises when ``strict=True`` (default)
+# and returns ``dataclasses.MISSING`` when ``strict=False`` so callers can
+# distinguish "absent" from "present and ``None``".
 
-    NOTE:
-    - Nested key are allowed. Support for "." notation, "[:?\\d+:?]" notation
+
+def _parse_segment(segment: str) -> tuple[str, str | None]:
+    """Split a path segment into ``(name, modifier)``.
+
+    ``modifier`` is the raw content between the brackets (e.g. ``"0"``,
+    ``"+"``, ``":2"``) or ``None`` when the segment has no bracket.
+
+    Raises ``ValueError`` on malformed syntax (unclosed bracket, empty name,
+    nested brackets).
+    """
+    if not segment:
+        raise ValueError("Empty path segment")
+    if "[" not in segment:
+        return segment, None
+    if not segment.endswith("]"):
+        raise ValueError(f"Malformed segment '{segment}': unclosed bracket")
+    name, _, rest = segment.partition("[")
+    if not name:
+        raise ValueError(f"Malformed segment '{segment}': missing key before '['")
+    modifier = rest[:-1]
+    if "[" in modifier or "]" in modifier:
+        raise ValueError(f"Malformed segment '{segment}': nested brackets")
+    return name, modifier.strip()
+
+
+def _apply_read_modifier(container: Any, name: str, modifier: str) -> Any:
+    """Apply a bracket modifier to a value fetched by ``name``.
+
+    Handles ``[i]``, ``[:n]``, and ``[n:]``. Rejects ``[+]`` (write-only).
+    """
+    if modifier == "+":
+        raise ValueError(f"Append modifier '[+]' is not valid on reads (segment '{name}[+]')")
+    if not hasattr(container, "__getitem__"):
+        raise TypeError(f"Expected indexable object but got {type(container)} for '{name}'")
+    if modifier.startswith(":"):
+        return container[: int(modifier[1:])]
+    if modifier.endswith(":"):
+        return container[int(modifier[:-1]) :]
+    return container[int(modifier)]
+
+
+def from_dict(dictionary: Dict[str, Any], key: str, *, strict: bool = True):
+    """Read a value from ``dictionary`` at the DSL path ``key``.
 
     Args:
-        dictionary (Dict[str, Any]): _description_
-        key (str): _description_
+        dictionary: The source dictionary to read from.
+        key: Dot/bracket path (see module-level DSL reference above).
+        strict: When ``True`` (default), raises ``KeyError`` if the terminal
+            segment is absent. When ``False``, returns ``dataclasses.MISSING``
+            for an absent terminal so callers can distinguish "missing" from
+            a present-but-``None`` value. Intermediate segments always raise
+            regardless of ``strict``.
 
     Returns:
-        _type_: _description_
+        The value at the path, or ``dataclasses.MISSING`` when the terminal
+        is absent and ``strict=False``.
+
+    Raises:
+        KeyError: Intermediate segment missing, or terminal missing with
+            ``strict=True``.
+        TypeError: Path traverses a non-indexable value (e.g. ``.key`` on a
+            list, ``[i]`` on a non-indexable).
+        ValueError: Malformed path syntax.
     """
-    # Step 1: Split into individual key segments
     key_segments = key.split(".")
+    name, modifier = _parse_segment(key_segments[0])
+    is_terminal = len(key_segments) == 1
 
-    # Step 2: Get value, if last key segment
-    if len(key_segments) == 1:
-        # Step 2.a: key with list notation
-        if key_segments[0].endswith("]"):
-            dict_key, pos_idx = key_segments[0].split("[")
+    # Presence check at this level (distinguishes "absent" from "None value").
+    if name not in dictionary:
+        if is_terminal and not strict:
+            return MISSING
+        raise KeyError(
+            f"Missing key '{name}' while resolving path '{key}'"
+            + ("" if is_terminal else " (intermediate segment)")
+        )
 
-            if not hasattr(dictionary.get(dict_key), "__getitem__"):
-                raise TypeError(
-                    f"Expected indexable object but got {type(dictionary.get(dict_key))} for {dict_key}"
-                )
+    current = dictionary[name]
 
-            pos_idx = pos_idx.rstrip("]").strip()
-            if pos_idx.startswith(":"):
-                return dictionary.get(dict_key)[: int(pos_idx[1:])]
-            elif pos_idx.endswith(":"):
-                return dictionary.get(dict_key)[: int(pos_idx[:-1])]
-            else:
-                return dictionary.get(dict_key)[int(pos_idx)]
-        else:
-            # Step 2.b: dictionary key
-            return dictionary.get(key_segments[0])
-    else:
-        # Step 3.a: key with list notation
-        if key_segments[0].endswith("]"):
-            dict_key, pos_idx = key_segments[0].split("[")
+    if is_terminal:
+        if modifier is None:
+            return current
+        return _apply_read_modifier(current, name, modifier)
 
-            if ":" in pos_idx.rstrip("]").strip():
-                raise ValueError("List notation ([:n], [n:]) is not allowed for intermediate keys.")
-
-            if not isinstance(dictionary.get(dict_key), list):
-                raise TypeError(
-                    f"Expected list but got {type(dictionary.get(dict_key))} for {dict_key}"
-                )
-
-            return from_dict(
-                dictionary=dictionary.get(dict_key)[int(pos_idx.rstrip("]").strip())],
-                key=".".join(key_segments[1:]),
+    # Intermediate segment: descend.
+    if modifier is not None:
+        if ":" in modifier:
+            raise ValueError(
+                f"Slice notation '[{modifier}]' is not allowed on intermediate segment '{name}'"
             )
-        else:
-            # Step 3.b: dictionary key
-            return from_dict(
-                dictionary=dictionary.get(key_segments[0]),
-                key=".".join(key_segments[1:]),
-            )
+        if modifier == "+":
+            raise ValueError(f"Append modifier '[+]' is not valid on reads (segment '{name}[+]')")
+        if not isinstance(current, list):
+            raise TypeError(f"Expected list at '{name}' but got {type(current).__name__}")
+        current = current[int(modifier)]
+
+    # ``None``-as-absent at intermediate level: a dict with ``None`` value is
+    # semantically equivalent to "no child here" for path traversal. Raise a
+    # clean KeyError rather than letting the recursive call crash on ``NoneType``.
+    if current is None:
+        raise KeyError(f"Intermediate value at '{name}' is None while resolving path '{key}'")
+    if not isinstance(current, dict):
+        raise TypeError(f"Expected dict at intermediate '{name}' but got {type(current).__name__}")
+
+    return from_dict(current, ".".join(key_segments[1:]), strict=strict)
 
 
-def to_dict(dictionary: Dict[str, Any], key: str, value: Any):
-    # Step 1: Split into individual key segments
+def to_dict(dictionary: Dict[str, Any], key: str, value: Any) -> None:
+    """Write ``value`` into ``dictionary`` at the DSL path ``key``.
+
+    Intermediate containers are auto-created when missing: plain segments
+    create ``dict``s, bracketed segments create ``list``s. An intermediate
+    value of ``None`` is treated as absent (a common dataclass default),
+    and the appropriate container is materialized in its place.
+
+    Args:
+        dictionary: The dictionary to mutate in place.
+        key: Dot/bracket path (see module-level DSL reference above).
+        value: The value to write at the terminal segment.
+
+    Raises:
+        TypeError: Traversal encounters a non-container at an intermediate
+            segment, or a bracket modifier targets a non-list.
+        IndexError: List index is out of range for an existing list.
+        ValueError: Malformed path, or slice notation used (write-only DSL
+            rejects ``[:n]`` / ``[n:]``).
+    """
     key_segments = key.split(".")
+    name, modifier = _parse_segment(key_segments[0])
+    is_terminal = len(key_segments) == 1
 
-    # Step 2: Set value, if last key segment
-    if len(key_segments) == 1:
-        # Step 2.a: key with list notation
-        if key_segments[0].endswith("]"):
-            # Step 2.a.i: Identify dictionary key and position index
-            dict_key, pos_idx = key_segments[0].split("[")
+    if modifier is None:
+        # Plain-name segment.
+        if is_terminal:
+            dictionary[name] = value
+            return
 
-            # Step 2.a.ii: Create empty list and set position index to 0, if necessary
-            if dict_key not in dictionary:
-                dictionary[dict_key] = [None]
-                pos_idx = 0
-            else:
-                # Step 2.a.ii.*: Raise error, if position index refers to multiple multiple indices
-                if ":" in pos_idx:
-                    raise ValueError("List notation ([:n], [n:]) is not allowed for  keys.")
-                else:
-                    # Step 2.a.ii.**: Parse position index
-                    pos_idx = int(pos_idx.rstrip("]").strip())
+        # Intermediate: auto-create dict if missing or None.
+        if dictionary.get(name) is None:
+            dictionary[name] = {}
+        elif not isinstance(dictionary[name], dict):
+            raise TypeError(
+                f"Expected dict at intermediate '{name}' but got {type(dictionary[name]).__name__}"
+            )
+        to_dict(dictionary[name], ".".join(key_segments[1:]), value)
+        return
 
-                    # Step 2.a.ii.***: Raise error, if value for the key of interest is not of type list
-                    if not isinstance(dictionary[dict_key], list):
-                        raise TypeError(
-                            f"Expected list for {dict_key} key but got {type(dictionary[dict_key])} type."
-                        )
+    # Bracketed segment.
+    if ":" in modifier:
+        raise ValueError(
+            f"Slice notation '[{modifier}]' is not allowed in writes (segment '{name}')"
+        )
 
-                    # Step 2.a.ii.****: Raise error, if position index is out of index range
-                    if len(dictionary[dict_key]) < pos_idx:
-                        raise IndexError(
-                            f"Cannot insert at index {pos_idx} for list with lengh = {len(dictionary[dict_key])}"
-                        )
+    existing = dictionary.get(name)
+    absent = existing is None
 
-            # Step 2.a.iii: Set value
-            dictionary[dict_key][pos_idx] = value
-        else:
-            dictionary[key_segments[0]] = value
+    if modifier == "+":
+        # Append: always produces a new slot.
+        if absent:
+            dictionary[name] = []
+            existing = dictionary[name]
+        elif not isinstance(existing, list):
+            raise TypeError(
+                f"Expected list for '{name}' to use '[+]' append, got {type(existing).__name__}"
+            )
+        if is_terminal:
+            existing.append(value)
+            return
+        # Intermediate [+]: append a fresh {} and descend into it.
+        existing.append({})
+        to_dict(existing[-1], ".".join(key_segments[1:]), value)
+        return
+
+    # Numeric index.
+    pos_idx = int(modifier)
+    if absent:
+        # Preserve legacy quirk (documented): terminal ``[i]`` on a missing
+        # key creates ``[None]`` and writes at position 0; intermediate
+        # ``[i]`` creates ``[{}]`` and descends.
+        placeholder = None if is_terminal else {}
+        dictionary[name] = [placeholder]
+        existing = dictionary[name]
+        pos_idx = 0
     else:
-        # Step 2.a: key with list notation
-        if key_segments[0].endswith("]"):
-            # Step 2.a.i: Identify dictionary key and position index
-            dict_key, pos_idx = key_segments[0].split("[")
+        if not isinstance(existing, list):
+            raise TypeError(f"Expected list for '{name}' but got {type(existing).__name__}")
+        if len(existing) <= pos_idx:
+            raise IndexError(
+                f"Cannot assign at index {pos_idx} for list '{name}' of length {len(existing)}"
+            )
 
-            # Step 2.a.ii: Create empty list and set position index to 0, if necessary
-            if dict_key not in dictionary:
-                dictionary[dict_key] = [{}]
-                pos_idx = 0
+    if is_terminal:
+        existing[pos_idx] = value
+        return
+    if existing[pos_idx] is None:
+        existing[pos_idx] = {}
+    elif not isinstance(existing[pos_idx], dict):
+        raise TypeError(
+            f"Expected dict at '{name}[{pos_idx}]' but got {type(existing[pos_idx]).__name__}"
+        )
+    to_dict(existing[pos_idx], ".".join(key_segments[1:]), value)
+
+
+# ===========================================================================
+#                       DATACLASS PROCESSOR
+# ===========================================================================
+# ``from_dataclass`` / ``to_dataclass`` walk heterogeneous object graphs
+# (dataclass → dict → list → ...) using the same DSL as ``from_dict`` /
+# ``to_dict``. Attribute creation on dataclasses is intentionally disallowed:
+# the whole point of declaring fields is that typos are bugs, not silent
+# attribute additions. Nested dicts / lists that live inside dataclass fields
+# still auto-create per the dict rules.
+
+
+def _declared_fields(obj: Any) -> set[str]:
+    """Return the set of declared field names on a dataclass instance."""
+    return {f.name for f in _dc_fields(obj)}
+
+
+def _get_node_child(node: Any, name: str, modifier: str | None, path: str, segment: str) -> Any:
+    """Fetch ``node[name]`` (dataclass/dict) then apply ``modifier`` if present.
+
+    Shared read helper for ``from_dataclass``. Raises consistent errors naming
+    the failing segment and the full path.
+    """
+    if is_dataclass(node):
+        if name not in _declared_fields(node):
+            raise AttributeError(
+                f"Dataclass {type(node).__name__} has no field '{name}' "
+                f"(segment '{segment}' of path '{path}')"
+            )
+        current = getattr(node, name)
+    elif isinstance(node, dict):
+        if name not in node:
+            raise KeyError(f"Missing key '{name}' while resolving path '{path}'")
+        current = node[name]
+    else:
+        raise TypeError(
+            f"Cannot traverse '{name}' on {type(node).__name__} "
+            f"(segment '{segment}' of path '{path}')"
+        )
+
+    if modifier is None:
+        return current
+    if modifier == "+":
+        raise ValueError(f"Append modifier '[+]' is not valid on reads (segment '{segment}')")
+    if not isinstance(current, list):
+        raise TypeError(
+            f"Expected list at '{name}' but got {type(current).__name__} "
+            f"(segment '{segment}' of path '{path}')"
+        )
+    if modifier.startswith(":"):
+        return current[: int(modifier[1:])]
+    if modifier.endswith(":"):
+        return current[int(modifier[:-1]) :]
+    return current[int(modifier)]
+
+
+def from_dataclass(obj: Any, path: str, *, strict: bool = True):
+    """Read a value from a dataclass (or mixed dataclass/dict/list graph) by path.
+
+    Args:
+        obj: The root object. Typically a dataclass instance; dicts and lists
+            encountered as intermediate nodes are walked using the same DSL
+            semantics as :func:`from_dict`.
+        path: Dot/bracket path.
+        strict: When ``True`` (default), a missing terminal raises. When
+            ``False``, returns ``dataclasses.MISSING``. Intermediate segments
+            always raise regardless of ``strict``. Dataclass field names that
+            are not declared always raise ``AttributeError`` — "not declared"
+            is a schema error, not a missing value.
+
+    Returns:
+        The value at the path, or ``dataclasses.MISSING`` when the terminal
+        is absent on a dict node and ``strict=False``.
+
+    Raises:
+        AttributeError: Dataclass field not declared at any segment.
+        KeyError: Dict intermediate key missing, or terminal missing when strict.
+        TypeError: Path traverses a non-traversable value.
+        ValueError: Malformed path syntax.
+    """
+    segments = path.split(".")
+    name, modifier = _parse_segment(segments[0])
+    is_terminal = len(segments) == 1
+
+    # Dataclass field not declared → always raise, even when not strict.
+    if is_dataclass(obj) and name not in _declared_fields(obj):
+        raise AttributeError(
+            f"Dataclass {type(obj).__name__} has no field '{name}' "
+            f"(segment '{segments[0]}' of path '{path}')"
+        )
+
+    # Dict terminal miss with strict=False → sentinel.
+    if isinstance(obj, dict) and is_terminal and name not in obj and not strict:
+        return MISSING
+
+    current = _get_node_child(obj, name, modifier, path, segments[0])
+
+    if is_terminal:
+        return current
+
+    if current is None:
+        raise KeyError(f"Intermediate value at '{name}' is None while resolving path '{path}'")
+    return from_dataclass(current, ".".join(segments[1:]), strict=strict)
+
+
+def _descend_for_write(node: Any, name: str, modifier: str | None, path: str, segment: str) -> Any:
+    """Return the child container at ``node[name]`` (+ modifier), auto-creating
+    intermediate ``None`` dataclass fields and dict entries per design rules.
+
+    Used by ``to_dataclass``. The caller decides what to do at the terminal;
+    this helper only handles intermediate descent.
+    """
+    if is_dataclass(node):
+        if name not in _declared_fields(node):
+            raise ValueError(
+                f"Dataclass {type(node).__name__} has no field '{name}' "
+                f"(segment '{segment}' of path '{path}'). "
+                f"Attributes cannot be auto-created on dataclasses."
+            )
+        current = getattr(node, name)
+        # ``None``-valued dataclass field behaves as "absent": materialize the
+        # correct container based on the modifier shape.
+        if current is None:
+            current = [] if modifier is not None else {}
+            setattr(node, name, current)
+    elif isinstance(node, dict):
+        current = node.get(name)
+        if current is None:
+            current = [] if modifier is not None else {}
+            node[name] = current
+    else:
+        raise TypeError(
+            f"Cannot descend into '{name}' on {type(node).__name__} "
+            f"(segment '{segment}' of path '{path}')"
+        )
+
+    if modifier is None:
+        if not isinstance(current, dict) and not is_dataclass(current):
+            raise TypeError(
+                f"Expected dict or dataclass at intermediate '{name}' "
+                f"but got {type(current).__name__}"
+            )
+        return current
+
+    # Bracketed modifier: descend into list.
+    if ":" in modifier:
+        raise ValueError(
+            f"Slice notation '[{modifier}]' is not allowed in writes (segment '{segment}')"
+        )
+    if not isinstance(current, list):
+        raise TypeError(f"Expected list for '{name}' but got {type(current).__name__}")
+    if modifier == "+":
+        current.append({})
+        return current[-1]
+    pos_idx = int(modifier)
+    if len(current) <= pos_idx:
+        raise IndexError(
+            f"Cannot descend into index {pos_idx} for list '{name}' of length {len(current)}"
+        )
+    child = current[pos_idx]
+    if child is None:
+        child = {}
+        current[pos_idx] = child
+    elif not isinstance(child, (dict,)) and not is_dataclass(child):
+        raise TypeError(
+            f"Expected dict or dataclass at '{name}[{pos_idx}]' but got {type(child).__name__}"
+        )
+    return child
+
+
+def to_dataclass(obj: Any, path: str, value: Any) -> None:
+    """Write ``value`` into a dataclass (or mixed graph) at DSL ``path``.
+
+    Mutates ``obj`` in place. Rules:
+
+    - Dataclass fields must be declared. Undeclared paths raise ``ValueError``.
+      This is a schema contract, not a missing-value condition.
+    - Dict keys and list slots auto-create per the :func:`to_dict` rules
+      (plain segment → ``{}``; bracket segment → ``[]``).
+    - An intermediate dataclass field that is ``None`` is treated as absent
+      and replaced with the appropriate container, keeping the common
+      ``Optional[Dict] = None`` pattern writable without manual initialization.
+    - ``SRC_DATA`` is reserved; writing to it at the terminal raises.
+    - No leaf-type enforcement. Python dataclasses do not enforce field types
+      at runtime and neither does this helper.
+
+    Args:
+        obj: The root object to mutate (dataclass, dict, or mixed graph).
+        path: Dot/bracket path.
+        value: The value to assign at the terminal.
+
+    Raises:
+        ValueError: Undeclared dataclass field, slice notation in path, or
+            write targets ``SRC_DATA`` at the terminal.
+        TypeError: Path traverses an incompatible type, or ``[+]`` targets a
+            non-list field.
+        IndexError: List index is out of range.
+    """
+    segments = path.split(".")
+    name, modifier = _parse_segment(segments[0])
+    is_terminal = len(segments) == 1
+
+    if is_terminal and name == "SRC_DATA":
+        raise ValueError("Cannot write to reserved field 'SRC_DATA'")
+
+    if modifier is None:
+        if is_terminal:
+            if is_dataclass(obj):
+                if name not in _declared_fields(obj):
+                    raise ValueError(
+                        f"Dataclass {type(obj).__name__} has no field '{name}' "
+                        f"(path '{path}'). Attributes cannot be auto-created on dataclasses."
+                    )
+                setattr(obj, name, value)
+            elif isinstance(obj, dict):
+                obj[name] = value
             else:
-                # Step 2.a.ii.*: Raise error, if position index refers to multiple multiple indices
-                if ":" in pos_idx:
-                    raise ValueError("List notation ([:n], [n:]) is not allowed for  keys.")
-                else:
-                    # Step 2.a.ii.**: Parse position index
-                    pos_idx = int(pos_idx.rstrip("]").strip())
+                raise TypeError(f"Cannot set '{name}' on {type(obj).__name__} (path '{path}')")
+            return
+        child = _descend_for_write(obj, name, None, path, segments[0])
+        to_dataclass(child, ".".join(segments[1:]), value)
+        return
 
-                    # Step 2.a.ii.***: Raise error, if existing value for the key of interest is not of type list
-                    if not isinstance(dictionary[dict_key], list):
-                        raise TypeError(
-                            f"Expected list for {dict_key} key but got {type(dictionary[dict_key])} type."
-                        )
+    # Bracketed segment.
+    if ":" in modifier:
+        raise ValueError(
+            f"Slice notation '[{modifier}]' is not allowed in writes (segment '{segments[0]}')"
+        )
 
-                    # Step 2.a.ii.****: Raise error, if position index is out of index range
-                    if len(dictionary[dict_key]) < pos_idx:
-                        raise IndexError(
-                            f"Cannot insert at index {pos_idx} for list with lengh = {len(dictionary[dict_key])}"
-                        )
-
-            # Step 2.a.iii: Continue recursive call
-            to_dict(
-                dictionary=dictionary[dict_key][pos_idx],
-                key=".".join(key_segments[1:]),
-                value=value,
+    # Resolve the list that holds this position.
+    if is_dataclass(obj):
+        if name not in _declared_fields(obj):
+            raise ValueError(
+                f"Dataclass {type(obj).__name__} has no field '{name}' "
+                f"(path '{path}'). Attributes cannot be auto-created on dataclasses."
             )
-
-        else:
-            # Step 2.b: Create empty dictionary with key_segment as the key
-            if key_segments[0] not in dictionary:
-                dictionary[key_segments[0]] = {}
-
-            # Step 2.c: Continue
-            to_dict(
-                dictionary=dictionary[key_segments[0]],
-                key=".".join(key_segments[1:]),
-                value=value,
+        lst = getattr(obj, name)
+        if lst is None:
+            lst = []
+            setattr(obj, name, lst)
+        elif not isinstance(lst, list):
+            raise TypeError(
+                f"Field '{name}' on {type(obj).__name__} is {type(lst).__name__}, "
+                f"cannot use bracket modifier"
             )
+    elif isinstance(obj, dict):
+        lst = obj.get(name)
+        if lst is None:
+            lst = []
+            obj[name] = lst
+        elif not isinstance(lst, list):
+            raise TypeError(f"Expected list for '{name}' but got {type(lst).__name__}")
+    else:
+        raise TypeError(f"Cannot descend into '{name}' on {type(obj).__name__} (path '{path}')")
+
+    if modifier == "+":
+        if is_terminal:
+            lst.append(value)
+            return
+        lst.append({})
+        to_dataclass(lst[-1], ".".join(segments[1:]), value)
+        return
+
+    pos_idx = int(modifier)
+    if is_terminal:
+        if len(lst) <= pos_idx:
+            raise IndexError(
+                f"Cannot assign at index {pos_idx} for list '{name}' of length {len(lst)}"
+            )
+        lst[pos_idx] = value
+        return
+
+    if len(lst) <= pos_idx:
+        raise IndexError(
+            f"Cannot descend into index {pos_idx} for list '{name}' of length {len(lst)}"
+        )
+    child = lst[pos_idx]
+    if child is None:
+        child = {}
+        lst[pos_idx] = child
+    elif not isinstance(child, dict) and not is_dataclass(child):
+        raise TypeError(
+            f"Expected dict or dataclass at '{name}[{pos_idx}]' but got {type(child).__name__}"
+        )
+    to_dataclass(child, ".".join(segments[1:]), value)

--- a/tests/base/test_block.py
+++ b/tests/base/test_block.py
@@ -1,0 +1,542 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :class:`Block`'s ``transform_input`` / ``transform_output``.
+
+Groups cases by route (dict ``src_data`` vs. dataclass ``src_data``) and by
+direction (input vs. output). Each section exercises the nested DSL on both
+sides of its ``*_map`` so the helpers and the branch logic are covered
+together.
+"""
+
+# Standard
+from dataclasses import MISSING, dataclass
+from typing import Any, Dict, List, Optional
+import dataclasses
+
+# Third Party
+import pytest
+
+# Local
+from fms_dgt.base.block import Block
+from fms_dgt.base.data_objects import BlockData, DataPoint
+from fms_dgt.utils import from_dataclass, to_dataclass
+
+
+# ===========================================================================
+#                       TEST FIXTURES
+# ===========================================================================
+class _NullBlock(Block):
+    """A DATA_TYPE=None block used purely to exercise transform_output.
+
+    Overriding ``__init__`` lets the tests construct it without going through
+    the full registry / datastore machinery.
+    """
+
+    DATA_TYPE = None
+
+    def __init__(self, output_map=None):
+        self._name = "_null"
+        self._block_type = "test"
+        self._input_map = None
+        self._output_map = output_map
+        self._req_args, self._opt_args = [], []
+
+
+@dataclass
+class _SamplePoint(DataPoint):
+    """A realistic user ``DataPoint`` for the dataclass-branch tests.
+
+    Inherits ``task_name`` / ``is_seed`` from :class:`DataPoint` and declares
+    the fields touched by the block's default ``output_map`` echo (``score``,
+    ``labels``, ``tag``, ``store_names``) plus extra fields that the tests
+    aim nested writes at (``tags``, ``annotations``, ``metadata``).
+    """
+
+    question: str = ""
+    score: Optional[float] = None
+    labels: Optional[Dict[str, Any]] = None
+    tag: Optional[str] = None
+    store_names: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+    annotations: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class _SampleBlockData(BlockData):
+    """A ``BlockData`` subclass that mirrors the magpie-style shape."""
+
+    score: float = 0.0
+    labels: Optional[Dict[str, Any]] = None
+    tag: Optional[str] = None
+
+
+class _DataclassBlock(Block):
+    """A block with a dataclass DATA_TYPE, for exercising the dataclass
+    branch of ``transform_output`` without standing up a full databuilder.
+    """
+
+    DATA_TYPE = _SampleBlockData
+
+    def __init__(self, output_map=None):
+        self._name = "_dc"
+        self._block_type = "test"
+        self._input_map = None
+        self._output_map = output_map
+        self._req_args = [
+            f.name
+            for f in dataclasses.fields(_SampleBlockData)
+            if f.default is dataclasses.MISSING and f.name != "SRC_DATA"
+        ]
+        self._opt_args = [
+            f.name
+            for f in dataclasses.fields(_SampleBlockData)
+            if f.default is not dataclasses.MISSING
+        ]
+
+
+def _build_inp(src, **extras):
+    """Mirror the real pipeline's ``inp`` construction for DATA_TYPE=None blocks.
+
+    ``transform_input`` passes every key from ``src_data`` through into ``inp``
+    alongside the block's own outputs, plus ``SRC_DATA``. Tests that call
+    ``transform_output`` directly must preserve that invariant, otherwise the
+    default-map's echo entries point at keys that don't exist on ``inp``.
+    """
+    return {**src, **extras, "SRC_DATA": src}
+
+
+# ===========================================================================
+#                       transform_output — dict src_data
+# ===========================================================================
+def test_flat_write_preserved():
+    """Flat paths on both sides behave identically to the pre-DSL implementation."""
+    block = _NullBlock(output_map={"tags": "result_tags"})
+    src = {"question": "q"}
+    inp = _build_inp(src, tags=["a", "b"])
+
+    out = block.transform_output(inp, {"tags": "result_tags"})
+
+    assert out is src
+    assert out == {"question": "q", "result_tags": ["a", "b"]}
+
+
+def test_nested_write_path_creates_intermediate_dicts():
+    """DSL path on the ``v`` side auto-creates nested dicts on the source row."""
+    block = _NullBlock()
+    src = {"question": "q"}
+    inp = _build_inp(src, score=0.9)
+
+    block.transform_output(inp, {"score": "annotations.magpie.score"})
+
+    assert src == {
+        "question": "q",
+        "annotations": {"magpie": {"score": 0.9}},
+    }
+
+
+def test_nested_read_path_from_block_output():
+    """DSL path on the ``k`` side reads nested values from the block's output dict."""
+    block = _NullBlock()
+    src = {}
+    inp = _build_inp(src, labels={"primary": "safe", "secondary": "low_risk"})
+
+    block.transform_output(inp, {"labels.primary": "safety_label"})
+
+    assert src == {"safety_label": "safe"}
+
+
+def test_nested_read_and_write_combined():
+    """DSL applies on both sides in a single entry."""
+    block = _NullBlock()
+    src = {}
+    inp = _build_inp(src, result={"scores": [{"value": 0.7}, {"value": 0.3}]})
+
+    block.transform_output(inp, {"result.scores[0].value": "metadata.top_score"})
+
+    assert src == {"metadata": {"top_score": 0.7}}
+
+
+def test_append_modifier_on_destination():
+    """``[+]`` grows a list on the source row across multiple calls."""
+    block = _NullBlock()
+    src = {}
+
+    block.transform_output(_build_inp(src, tag="a"), {"tag": "tags[+]"})
+    block.transform_output(_build_inp(src, tag="b"), {"tag": "tags[+]"})
+
+    assert src == {"tags": ["a", "b"]}
+
+
+def test_append_intermediate_grows_list_of_annotations():
+    """``[+]`` at an intermediate segment appends a fresh dict and descends."""
+    block = _NullBlock()
+    src = {}
+
+    block.transform_output(_build_inp(src, score=0.9), {"score": "annotations[+].magpie.score"})
+    block.transform_output(_build_inp(src, score=0.4), {"score": "annotations[+].magpie.score"})
+
+    assert src == {
+        "annotations": [
+            {"magpie": {"score": 0.9}},
+            {"magpie": {"score": 0.4}},
+        ]
+    }
+
+
+def test_missing_k_raises_keyerror():
+    """A typo in the ``k`` side surfaces as a KeyError rather than silent ``None``."""
+    block = _NullBlock()
+    src = {}
+    inp = _build_inp(src, actual_field=1)
+
+    with pytest.raises(KeyError):
+        block.transform_output(inp, {"typo_field": "result"})
+
+
+def test_none_intermediate_on_destination_treated_as_absent():
+    """An ``Optional[Dict] = None`` style source field is materialized on write."""
+    block = _NullBlock()
+    src = {"magpie_tags": None}
+    inp = _build_inp(src, label="gold")
+
+    block.transform_output(inp, {"label": "magpie_tags.metadata.label"})
+
+    assert src == {"magpie_tags": {"metadata": {"label": "gold"}}}
+
+
+def test_present_none_value_flows_through():
+    """A block output that is present and ``None`` must be written as ``None``, not treated as missing."""
+    block = _NullBlock()
+    src = {}
+    inp = _build_inp(src, maybe=None)
+
+    block.transform_output(inp, {"maybe": "annotations.maybe"})
+
+    assert src == {"annotations": {"maybe": None}}
+
+
+# ===========================================================================
+#                       utils.from_dataclass / utils.to_dataclass
+# ===========================================================================
+def test_from_dataclass_reads_flat_field():
+    obj = _SamplePoint(task_name="t", question="q", tags=["a"])
+    assert from_dataclass(obj, "tags") == ["a"]
+
+
+def test_from_dataclass_reads_through_dict():
+    obj = _SamplePoint(task_name="t", question="q", annotations={"magpie": {"score": 0.9}})
+    assert from_dataclass(obj, "annotations.magpie.score") == 0.9
+
+
+def test_from_dataclass_reads_through_list():
+    obj = _SamplePoint(task_name="t", question="q", tags=["a", "b", "c"])
+    assert from_dataclass(obj, "tags[1]") == "b"
+
+
+def test_from_dataclass_undeclared_field_raises():
+    obj = _SamplePoint(task_name="t", question="q")
+    with pytest.raises(AttributeError):
+        from_dataclass(obj, "no_such_field")
+
+
+def test_from_dataclass_undeclared_field_raises_even_when_not_strict():
+    """Schema errors are never silenced, unlike missing dict keys."""
+    obj = _SamplePoint(task_name="t", question="q")
+    with pytest.raises(AttributeError):
+        from_dataclass(obj, "no_such_field", strict=False)
+
+
+def test_from_dataclass_missing_dict_terminal_strict_raises():
+    obj = _SamplePoint(task_name="t", question="q", annotations={"magpie": {"score": 0.9}})
+    with pytest.raises(KeyError):
+        from_dataclass(obj, "annotations.missing")
+
+
+def test_from_dataclass_missing_dict_terminal_non_strict_returns_missing():
+    obj = _SamplePoint(task_name="t", question="q", annotations={"magpie": {"score": 0.9}})
+    assert from_dataclass(obj, "annotations.missing", strict=False) is MISSING
+
+
+def test_from_dataclass_none_intermediate_raises():
+    """A declared field whose value is None is not traversable on reads."""
+    obj = _SamplePoint(task_name="t", question="q", annotations=None)
+    with pytest.raises(KeyError):
+        from_dataclass(obj, "annotations.magpie")
+
+
+def test_to_dataclass_sets_flat_field():
+    obj = _SamplePoint(task_name="t", question="q")
+    to_dataclass(obj, "tags", ["a", "b"])
+    assert obj.tags == ["a", "b"]
+
+
+def test_to_dataclass_materializes_none_optional_dict_field():
+    """Intermediate None on a declared dataclass field is replaced on write."""
+    obj = _SamplePoint(task_name="t", question="q", annotations=None)
+    to_dataclass(obj, "annotations.magpie.score", 0.9)
+    assert obj.annotations == {"magpie": {"score": 0.9}}
+
+
+def test_to_dataclass_materializes_none_optional_list_field():
+    """Intermediate None with a bracket modifier creates a fresh list."""
+    obj = _SamplePoint(task_name="t", question="q", tags=None)
+    to_dataclass(obj, "tags[+]", "alpha")
+    to_dataclass(obj, "tags[+]", "beta")
+    assert obj.tags == ["alpha", "beta"]
+
+
+def test_to_dataclass_append_intermediate_grows_list_of_dicts():
+    obj = _SamplePoint(task_name="t", question="q")
+    to_dataclass(obj, "annotations.entries[+].name", "a")
+    to_dataclass(obj, "annotations.entries[+].name", "b")
+    assert obj.annotations == {"entries": [{"name": "a"}, {"name": "b"}]}
+
+
+def test_to_dataclass_undeclared_field_raises_valueerror():
+    """Typos on dataclass fields must fail — never silently create attributes."""
+    obj = _SamplePoint(task_name="t", question="q")
+    with pytest.raises(ValueError):
+        to_dataclass(obj, "no_such_field", "x")
+
+
+def test_to_dataclass_undeclared_nested_field_raises():
+    """Undeclared fields raise at any depth, not only at the terminal."""
+
+    @dataclass
+    class _Outer:
+        inner: Optional["_Inner"] = None
+
+    @dataclass
+    class _Inner:
+        x: Optional[int] = None
+
+    # declare before use: rebuild via assignment order
+    outer = _Outer(inner=_Inner(x=1))
+    with pytest.raises(ValueError):
+        to_dataclass(outer, "inner.y", 2)
+
+
+def test_to_dataclass_reserved_src_data_raises():
+    obj = _SamplePoint(task_name="t", question="q")
+    with pytest.raises(ValueError):
+        to_dataclass(obj, "SRC_DATA", "oops")
+
+
+def test_to_dataclass_bracket_on_non_list_field_raises():
+    """``[+]`` targeting a declared field that isn't a list is an error."""
+    obj = _SamplePoint(task_name="t", question="q", annotations={"magpie": {}})
+    with pytest.raises(TypeError):
+        to_dataclass(obj, "question[+]", "x")
+
+
+def test_to_dataclass_slice_write_rejected():
+    obj = _SamplePoint(task_name="t", question="q", tags=["a"])
+    with pytest.raises(ValueError):
+        to_dataclass(obj, "tags[:1]", "x")
+
+
+# ===========================================================================
+#                       transform_output — dataclass src_data
+# ===========================================================================
+def _dc_inp(src, **fields_to_set):
+    """Build a ``_SampleBlockData`` instance matching what transform_input would produce.
+
+    The real pipeline populates every declared field (required + optional,
+    with defaults) before handing ``inp`` to ``execute`` / ``transform_output``,
+    plus ``SRC_DATA``. Mirror that so the default-map echo has every key it expects.
+    """
+    return _SampleBlockData(SRC_DATA=src, **fields_to_set)
+
+
+def test_transform_output_dataclass_flat_write():
+    """Flat dataclass write works end-to-end (regression guard)."""
+    block = _DataclassBlock(output_map={"score": "metadata"})
+    src = _SamplePoint(task_name="t", question="q")
+    inp = _dc_inp(src, score=0.75)
+
+    out = block.transform_output(inp, {"score": "metadata"})
+
+    assert out is src
+    # ``_SamplePoint.metadata`` is declared ``Optional[Dict[str, Any]]``; setattr
+    # assigns the raw value without leaf-type enforcement.
+    assert out.metadata == 0.75
+
+
+def test_transform_output_dataclass_nested_write_creates_dict():
+    """Nested path on ``v`` materializes dict inside a ``None`` dataclass field."""
+    block = _DataclassBlock()
+    src = _SamplePoint(task_name="t", question="q", annotations=None)
+    inp = _dc_inp(src, score=0.9)
+
+    block.transform_output(inp, {"score": "annotations.magpie.score"})
+
+    assert src.annotations == {"magpie": {"score": 0.9}}
+
+
+def test_transform_output_dataclass_append_grows_list_field():
+    """``[+]`` on a dataclass list field appends across calls."""
+    block = _DataclassBlock()
+    src = _SamplePoint(task_name="t", question="q", tags=None)
+
+    block.transform_output(_dc_inp(src, tag="a"), {"tag": "tags[+]"})
+    block.transform_output(_dc_inp(src, tag="b"), {"tag": "tags[+]"})
+
+    assert src.tags == ["a", "b"]
+
+
+def test_transform_output_dataclass_undeclared_destination_raises():
+    """The old ``hasattr`` silent-skip is intentionally gone; typos must raise."""
+    block = _DataclassBlock()
+    src = _SamplePoint(task_name="t", question="q")
+    inp = _dc_inp(src, score=0.5)
+
+    with pytest.raises(ValueError):
+        block.transform_output(inp, {"score": "typo_field"})
+
+
+def test_transform_output_dataclass_nested_read_from_dict_inp():
+    """``k`` side DSL works when the block produced a DATA_TYPE=None dict."""
+
+    class _NestedOutputBlock(Block):
+        DATA_TYPE = None
+
+        def __init__(self):
+            self._name = "_n"
+            self._block_type = "test"
+            self._input_map = None
+            self._output_map = None
+            self._req_args, self._opt_args = [], []
+
+    block = _NestedOutputBlock()
+    src = _SamplePoint(task_name="t", question="q")
+    # DATA_TYPE=None + dataclass src_data: the default map echoes every
+    # declared field of ``src_data`` via ``_get_default_map``. Build ``inp``
+    # so each of those fields has a value to read, mirroring what the real
+    # pipeline produces via ``transform_input``.
+    inp = {f.name: getattr(src, f.name) for f in dataclasses.fields(src) if f.name != "SRC_DATA"}
+    inp["SRC_DATA"] = src
+    inp["result"] = {"scores": [{"value": 0.7}]}
+
+    block.transform_output(inp, {"result.scores[0].value": "metadata.top_score"})
+
+    assert src.metadata == {"top_score": 0.7}
+
+
+# ===========================================================================
+#                       transform_input — dict src_data
+# ===========================================================================
+class _InputBlock(Block):
+    """Block with a real dataclass DATA_TYPE for exercising ``transform_input``.
+
+    Constructor bypasses the registry / datastore machinery; ``_req_args`` and
+    ``_opt_args`` mirror what ``Block.__init__`` would compute from
+    :class:`_SampleBlockData`.
+    """
+
+    DATA_TYPE = _SampleBlockData
+
+    def __init__(self, input_map=None):
+        self._name = "_in"
+        self._block_type = "test"
+        self._input_map = input_map
+        self._output_map = None
+        self._req_args = [
+            f.name
+            for f in dataclasses.fields(_SampleBlockData)
+            if f.default is dataclasses.MISSING and f.name != "SRC_DATA"
+        ]
+        self._opt_args = [
+            f.name
+            for f in dataclasses.fields(_SampleBlockData)
+            if f.default is not dataclasses.MISSING
+        ]
+
+
+def test_transform_input_flat_mapping():
+    """A flat input_map routes row fields to declared dataclass args."""
+    block = _InputBlock(input_map={"question_text": "labels"})
+    row = {"question_text": {"primary": "safe"}}
+
+    out = block.transform_input(row, block._input_map)
+
+    assert out.labels == {"primary": "safe"}
+    assert out.SRC_DATA is row
+
+
+def test_transform_input_missing_optional_source_falls_back_to_default():
+    """An optional source field that's absent on the row lets the dataclass default apply."""
+    block = _InputBlock(input_map={"missing_key": "labels"})
+    row = {"question_text": "q"}
+
+    out = block.transform_input(row, block._input_map)
+
+    # labels declared default is None; absence of "missing_key" must not override it.
+    assert out.labels is None
+
+
+def test_transform_input_present_none_flows_through():
+    """A row key whose value is None passes None through, not default."""
+    block = _InputBlock(input_map={"maybe": "labels"})
+    row = {"maybe": None}
+
+    out = block.transform_input(row, block._input_map)
+
+    # None is a real value and must win over the dataclass default.
+    assert out.labels is None  # matches default here, but see next test for distinction
+
+
+def test_transform_input_nested_path_reads_terminal():
+    """Nested DSL on the input_map reads through dicts and lists."""
+    block = _InputBlock(input_map={"messages[0].content": "tag"})
+    row = {"messages": [{"content": "hello"}, {"content": "world"}]}
+
+    out = block.transform_input(row, block._input_map)
+
+    assert out.tag == "hello"
+
+
+def test_transform_input_nested_terminal_missing_falls_back_to_default():
+    """Nested path whose terminal is absent behaves like flat absent: default applies."""
+    block = _InputBlock(input_map={"messages[0].missing": "tag"})
+    row = {"messages": [{"content": "hello"}]}
+
+    out = block.transform_input(row, block._input_map)
+
+    assert out.tag is None  # declared default on _SampleBlockData.tag
+
+
+def test_transform_input_nested_intermediate_missing_raises():
+    """Intermediate segment absent means the user asserted a shape the row lacks — loud error."""
+    block = _InputBlock(input_map={"messages[0].content": "tag"})
+    row = {"question_text": "q"}  # no 'messages' at all
+
+    with pytest.raises(KeyError):
+        block.transform_input(row, block._input_map)
+
+
+def test_transform_input_missing_required_arg_raises_valueerror():
+    """A required dataclass field with no resolvable source must raise the existing error."""
+
+    @dataclass(kw_only=True)
+    class _RequiredBlockData(BlockData):
+        needed: str  # no default → becomes a required arg
+
+    class _RequiredBlock(Block):
+        DATA_TYPE = _RequiredBlockData
+
+        def __init__(self):
+            self._name = "_r"
+            self._block_type = "test"
+            self._input_map = None
+            self._output_map = None
+            self._req_args = ["needed"]
+            self._opt_args = []
+
+    block = _RequiredBlock()
+    # Row has no mapping for "needed" and no input_map provided.
+    row = {"unrelated": "value"}
+
+    with pytest.raises(ValueError):
+        block.transform_input(row, None)

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,6 +1,12 @@
 # Copyright The DiGiT Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Standard
+from dataclasses import MISSING
+
+# Third Party
+import pytest
+
 # Local
 from fms_dgt.utils import from_dict, group_by, sanitize_path, to_dict
 
@@ -73,37 +79,145 @@ def test_from_dict():
         }
     }
 
-    assert from_dict(dictionary=reference, key="key_1.key_2.key_4"), "key_4_value"
-    assert from_dict(dictionary=reference, key="key_1.key_2.key_3"), [
+    assert from_dict(dictionary=reference, key="key_1.key_2.key_4") == "key_4_value"
+    assert from_dict(dictionary=reference, key="key_1.key_2.key_3") == [
         {"list_key_1": "list_value_1"},
         {"list_key_2": {"list_key_2_value_1": {"list_key_2_value_1_list_1": [1, 2, 3]}}},
         {"list_key_3": "list_value_3"},
     ]
-    assert from_dict(dictionary=reference, key="key_1.key_2.key_3[1:]"), [
+    assert from_dict(dictionary=reference, key="key_1.key_2.key_3[1:]") == [
         {"list_key_2": {"list_key_2_value_1": {"list_key_2_value_1_list_1": [1, 2, 3]}}},
         {"list_key_3": "list_value_3"},
     ]
-    assert from_dict(dictionary=reference, key="key_1.key_2.key_3[:1]"), [
+    assert from_dict(dictionary=reference, key="key_1.key_2.key_3[:1]") == [
         {"list_key_1": "list_value_1"},
     ]
     assert from_dict(
         dictionary=reference, key="key_1.key_2.key_3[1].list_key_2.list_key_2_value_1"
-    ), {"list_key_2_value_1_list_1": [1, 2, 3]}
+    ) == {"list_key_2_value_1_list_1": [1, 2, 3]}
+
+
+def test_from_dict_strict_raises_on_missing_terminal():
+    """Default behavior raises KeyError when the terminal segment is absent."""
+    reference = {"a": {"b": 1}}
+    with pytest.raises(KeyError):
+        from_dict(reference, "a.missing")
+    with pytest.raises(KeyError):
+        from_dict(reference, "missing")
+
+
+def test_from_dict_non_strict_returns_missing_sentinel():
+    """strict=False returns dataclasses.MISSING for absent terminal keys."""
+    reference = {"a": {"b": 1}}
+    assert from_dict(reference, "a.missing", strict=False) is MISSING
+    assert from_dict(reference, "missing", strict=False) is MISSING
+
+
+def test_from_dict_present_none_value_returns_none_even_when_non_strict():
+    """A terminal that resolves to None must be distinguishable from absent."""
+    reference = {"a": {"b": None}}
+    # Present-and-None: returns None, not MISSING, in both modes.
+    assert from_dict(reference, "a.b") is None
+    assert from_dict(reference, "a.b", strict=False) is None
+
+
+def test_from_dict_intermediate_missing_always_raises():
+    """Intermediate segment absence raises regardless of strict flag."""
+    reference = {"a": {"b": 1}}
+    with pytest.raises(KeyError):
+        from_dict(reference, "missing.b")
+    with pytest.raises(KeyError):
+        from_dict(reference, "missing.b", strict=False)
+
+
+def test_from_dict_intermediate_none_raises_cleanly():
+    """Intermediate value of None raises KeyError rather than crashing on NoneType."""
+    reference = {"a": None}
+    with pytest.raises(KeyError):
+        from_dict(reference, "a.b")
+    with pytest.raises(KeyError):
+        from_dict(reference, "a.b", strict=False)
+
+
+def test_from_dict_rejects_append_modifier():
+    """[+] is a write-only DSL element and must be rejected on reads."""
+    with pytest.raises(ValueError):
+        from_dict({"a": [1]}, "a[+]")
 
 
 def test_to_dict():
     reference = {}
     to_dict(dictionary=reference, key="key_1.key_2[0]", value="value_1")
-    assert {"key_1": {"key_2": ["value_1"]}}, reference
+    assert reference == {"key_1": {"key_2": ["value_1"]}}
 
     reference = {}
     to_dict(dictionary=reference, key="key_1.key_2[0].key_3", value="value_1")
-    assert {"key_1": {"key_2": [{"key_3": "value_1"}]}}, reference
+    assert reference == {"key_1": {"key_2": [{"key_3": "value_1"}]}}
 
     reference = {"key_1": {"key_2": [{"key_3": "value_1"}]}}
     to_dict(dictionary=reference, key="key_1.key_2[0].key_3", value="value_N")
-    assert {"key_1": {"key_2": [{"key_3": "value_N"}]}}, reference
+    assert reference == {"key_1": {"key_2": [{"key_3": "value_N"}]}}
 
     reference = {"key_1": {"key_2": [{"key_3": "value_1"}]}}
     to_dict(dictionary=reference, key="key_1.key_2", value="value_N")
-    assert {"key_1": {"key_2": "value_N"}}, reference
+    assert reference == {"key_1": {"key_2": "value_N"}}
+
+
+def test_to_dict_append_terminal_creates_list():
+    """Terminal [+] on a missing key creates an empty list and appends."""
+    reference = {}
+    to_dict(reference, "items[+]", "first")
+    assert reference == {"items": ["first"]}
+    to_dict(reference, "items[+]", "second")
+    assert reference == {"items": ["first", "second"]}
+
+
+def test_to_dict_append_terminal_existing_list():
+    """Terminal [+] on an existing list appends without overwriting."""
+    reference = {"items": ["a", "b"]}
+    to_dict(reference, "items[+]", "c")
+    assert reference == {"items": ["a", "b", "c"]}
+
+
+def test_to_dict_append_intermediate_descends_into_new_dict():
+    """Intermediate [+] appends a fresh dict and descends into it."""
+    reference = {}
+    to_dict(reference, "annotations[+].magpie.score", 0.9)
+    assert reference == {"annotations": [{"magpie": {"score": 0.9}}]}
+    to_dict(reference, "annotations[+].magpie.score", 0.7)
+    assert reference == {
+        "annotations": [
+            {"magpie": {"score": 0.9}},
+            {"magpie": {"score": 0.7}},
+        ]
+    }
+
+
+def test_to_dict_append_rejects_non_list_target():
+    """[+] on a key that already holds a non-list must raise TypeError."""
+    reference = {"items": "not a list"}
+    with pytest.raises(TypeError):
+        to_dict(reference, "items[+]", "x")
+
+
+def test_to_dict_rejects_slice_notation():
+    """Writes never accept slice modifiers."""
+    reference = {}
+    with pytest.raises(ValueError):
+        to_dict(reference, "items[:2]", "x")
+    with pytest.raises(ValueError):
+        to_dict(reference, "items[1:]", "x")
+
+
+def test_to_dict_none_as_absent_intermediate():
+    """An intermediate value of None is treated as absent (auto-creates)."""
+    reference = {"magpie_tags": None}
+    to_dict(reference, "magpie_tags.metadata.label", "gold")
+    assert reference == {"magpie_tags": {"metadata": {"label": "gold"}}}
+
+
+def test_to_dict_none_as_absent_for_list_intermediate():
+    """Intermediate None with a bracket-next segment creates a fresh list."""
+    reference = {"entries": None}
+    to_dict(reference, "entries[+].name", "alice")
+    assert reference == {"entries": [{"name": "alice"}]}


### PR DESCRIPTION
  <!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it
  
Extend transform_input / transform_output to support nested paths (dotted access, [i] index, [+] append) on both read and write sides, for dict and dataclass src_data. Enables enrichment blocks to place output at arbitrary DataPoint locations without schema bloat or custom plumbing in databuilders.

### utils:
  - from_dict gains strict: bool; returns dataclasses.MISSING when strict=False and terminal is absent (so callers distinguish absent from present-but-None). Intermediate misses always raise.
  - to_dict gains [+] append notation. Slice writes rejected. None-as- absent bug fixed on both helpers. Fixed pre-existing [n:] slice bug on from_dict surfaced by corrected test assertions.
  - New from_dataclass / to_dataclass walk mixed dataclass/dict/list graphs without round-tripping through asdict. Undeclared dataclass fields always raise; Optional[Dict]=None fields materialize on intermediate writes; SRC_DATA terminal writes guarded.

### Block:
  - transform_output: both routes use the DSL on k and v. Dataclass branch's hasattr silent-skip removed (typos now raise on row 1).
  - transform_input: swap flat .get for from_dict(strict=False) + is MISSING check. Missing terminals fall back to DATA_TYPE default; missing intermediates on nested paths raise loudly.

### Tests:
  - test_utils.py: +13 tests; fixed pre-existing truthy-with-message assertion bug.
  - test_block.py (new): 38 tests covering both routes, both directions.

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
