### PR TITLE
fix(block,constants): guard transform_output default-map from framework bookkeeping leak

### DIFF
--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -27,6 +27,7 @@ from fms_dgt.constants import (
     DATASET_TYPE,
     DGT_DIR,
     STORE_NAME_KEY,
+    STORE_NAMES_KEY,
     TASK_NAME_KEY,
     TYPE_KEY,
 )
@@ -39,6 +40,23 @@ from fms_dgt.utils import to_dict as _to_dict
 #                       CONSTATNTS
 # ===========================================================================
 _SRC_DATA = "SRC_DATA"
+
+# Framework-reserved fields on BlockData / ValidatorBlockData that the default
+# output_map must never round-trip back onto SRC_DATA. These are sidecar
+# attributes the framework attaches for its own use, not payload:
+#
+# - SRC_DATA: the original user row, carried on BlockData so transform_output
+#   can write back onto it. Echoing it to itself is nonsense.
+# - store_names: input-only routing metadata. The databuilder decides per-call
+#   which datastore(s) a block's rejects go to (see get_block_store_names and
+#   Block.save_data's dispatch at the store_names iteration below). Letting it
+#   escape back onto the user's DataPoint would conflate payload and routing
+#   and make save_data's dispatch depend on transform_output ordering.
+#
+# A caller who explicitly lists one of these in their output_map still gets
+# the strict behavior in transform_output; only the framework-synthesized
+# default is trimmed here.
+_FRAMEWORK_FIELDS = frozenset({_SRC_DATA, STORE_NAMES_KEY})
 
 
 # ===========================================================================
@@ -386,7 +404,12 @@ class Block:
         if output_map is None:
             output_map = dict()
 
-        # start with assuming elements of input will be used
+        # Keep the caller-declared keys distinct from the framework-synthesized
+        # default so the strict-raise from commit 7659d86 only fires on caller
+        # typos, not on default-map entries for fields SRC_DATA happens not to
+        # declare. A user DataPoint that omits e.g. ``is_valid`` should not
+        # raise when a ValidatorBlock's default echo tries to write it back.
+        user_declared = set(output_map)
         output_map = {**self._get_default_map(src_data), **output_map}
 
         if is_dataclass(src_data):
@@ -400,7 +423,15 @@ class Block:
                     attr_val = _from_dict(inp, k)
                 else:
                     attr_val = _from_dataclass(inp, k)
-                _to_dataclass(src_data, path, attr_val)
+                try:
+                    _to_dataclass(src_data, path, attr_val)
+                except ValueError:
+                    if k in user_declared:
+                        raise
+                    # Framework-synthesized default for a field SRC_DATA doesn't
+                    # declare; silently skip (this is exactly the narrow case
+                    # the pre-7659d86 hasattr skip was protecting).
+                    continue
         elif isinstance(src_data, (dict, pd.DataFrame, Dataset)):
             # TODO: handle things other than dictionaries (pd.DataFrame / Dataset
             # rows are dicts by the time they reach here; full DataFrame / Dataset
@@ -428,7 +459,7 @@ class Block:
         else:
             fields = data.keys() if isinstance(data, dict) else dataclasses.fields(data)
         fields = [f if isinstance(f, str) else f.name for f in fields]
-        return {f: f for f in fields if f != _SRC_DATA}
+        return {f: f for f in fields if f not in _FRAMEWORK_FIELDS}
 
     # ===========================================================================
     #                       MAIN FUNCTIONS

--- a/fms_dgt/base/databuilder/base.py
+++ b/fms_dgt/base/databuilder/base.py
@@ -24,6 +24,7 @@ from fms_dgt.constants import (
     DATASTORES_KEY,
     NAME_KEY,
     STORE_NAME_KEY,
+    STORE_NAMES_KEY,
     TASK_NAME_KEY,
     TYPE_KEY,
 )
@@ -490,7 +491,7 @@ class DataBuilder:
                         [
                             {
                                 **data_point,
-                                "store_names": self.get_block_store_names(
+                                STORE_NAMES_KEY: self.get_block_store_names(
                                     block_name=block_name,
                                     task_name=data_point[TASK_NAME_KEY],
                                 ),

--- a/fms_dgt/constants.py
+++ b/fms_dgt/constants.py
@@ -17,6 +17,11 @@ DATASET_TYPE = Iterable[DATASET_ROW_TYPE] | pd.DataFrame | Dataset
 TYPE_KEY = "type"
 NAME_KEY = "name"
 STORE_NAME_KEY = "store_name"
+# Wire-format key for the input-only routing metadata on BlockData. The
+# databuilder layer injects this key into rows on the way into a block; the
+# block layer reads the corresponding attribute in save_data to dispatch
+# rejects to the right datastore(s). Not a payload field.
+STORE_NAMES_KEY = "store_names"
 
 # Task specific
 RUNNER_CONFIG_KEY = "runner_config"

--- a/fms_dgt/public/databuilders/instructlab/knowledge/generate.py
+++ b/fms_dgt/public/databuilders/instructlab/knowledge/generate.py
@@ -10,6 +10,7 @@ from fms_dgt.base.databuilder import GenerationDataBuilder
 from fms_dgt.base.prompt import JinjaPromptTemplate
 from fms_dgt.base.registry import register_data_builder
 from fms_dgt.base.task import GenerationTask
+from fms_dgt.constants import STORE_NAMES_KEY
 from fms_dgt.core.blocks.llm import LMProvider
 from fms_dgt.core.blocks.validators.lm_judge import LMJudgeValidator
 from fms_dgt.public.blocks.magpie.tag import MagpieTagger
@@ -211,7 +212,7 @@ class KnowledgeDataBuilder(GenerationDataBuilder):
             # Build validator inputs
             validator_inputs: List[Dict] = [
                 {
-                    "store_names": self.get_block_store_names(
+                    STORE_NAMES_KEY: self.get_block_store_names(
                         block_name=self.validator.name,
                         task_name=question_answer_pair.task_name,
                     ),

--- a/fms_dgt/public/databuilders/instructlab/skills/generate.py
+++ b/fms_dgt/public/databuilders/instructlab/skills/generate.py
@@ -10,6 +10,7 @@ from fms_dgt.base.databuilder import GenerationDataBuilder
 from fms_dgt.base.prompt import JinjaPromptTemplate
 from fms_dgt.base.registry import register_data_builder
 from fms_dgt.base.task import GenerationTask
+from fms_dgt.constants import STORE_NAMES_KEY
 from fms_dgt.core.blocks.llm import LMProvider
 from fms_dgt.core.blocks.validators.lm_judge import LMJudgeValidator
 from fms_dgt.public.blocks.magpie.tag import MagpieTagger
@@ -286,7 +287,7 @@ class SkillsDataBuilder(GenerationDataBuilder):
                 "success_func": lambda x: utils.parse_response_string(x) == 1.0,
                 "gen_kwargs": {"stop": prompt_template.stop},
                 "reference": data_point,
-                "store_names": self.get_block_store_names(
+                STORE_NAMES_KEY: self.get_block_store_names(
                     block_name=self.validator.name, task_name=data_point.task_name
                 ),
                 "task_name": data_point.task_name,
@@ -353,7 +354,7 @@ class SkillsDataBuilder(GenerationDataBuilder):
                 "success_func": lambda x: utils.parse_response_string(x) > 1.0,
                 "gen_kwargs": {"stop": prompt_template.stop},
                 "reference": data_point,
-                "store_names": self.get_block_store_names(
+                STORE_NAMES_KEY: self.get_block_store_names(
                     block_name=self.validator.name, task_name=data_point.task_name
                 ),
             }
@@ -485,7 +486,7 @@ class SkillsDataBuilder(GenerationDataBuilder):
                 "success_func": lambda x: utils.parse_response_string(x) == 1.0,
                 "gen_kwargs": {"stop": prompt_template.stop},
                 "reference": data_point,
-                "store_names": self.get_block_store_names(
+                STORE_NAMES_KEY: self.get_block_store_names(
                     block_name=self.validator.name, task_name=data_point.task_name
                 ),
                 "task_name": data_point.task_name,
@@ -554,7 +555,7 @@ class SkillsDataBuilder(GenerationDataBuilder):
                 "success_func": lambda x: utils.parse_response_string(x) > 1.0,
                 "gen_kwargs": {"stop": prompt_template.stop},
                 "reference": data_point,
-                "store_names": self.get_block_store_names(
+                STORE_NAMES_KEY: self.get_block_store_names(
                     block_name=self.validator.name, task_name=data_point.task_name
                 ),
                 "task_name": data_point.task_name,

--- a/fms_dgt/public/databuilders/magpie/generate.py
+++ b/fms_dgt/public/databuilders/magpie/generate.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional
 # Local
 from fms_dgt.base.databuilder import TransformationDataBuilder
 from fms_dgt.base.registry import register_data_builder
+from fms_dgt.constants import STORE_NAMES_KEY
 from fms_dgt.public.blocks.magpie.distance import MagpieDistance
 from fms_dgt.public.blocks.magpie.filter import MagpieFilter
 from fms_dgt.public.blocks.magpie.tag import MagpieTagger
@@ -102,7 +103,7 @@ class MagpieTransformDataBuilder(TransformationDataBuilder):
                 [
                     {
                         **output,
-                        "store_names": self.get_block_store_names(
+                        STORE_NAMES_KEY: self.get_block_store_names(
                             block_name=self.filter.name, task_name=output["task_name"]
                         ),
                     }

--- a/tests/base/test_block.py
+++ b/tests/base/test_block.py
@@ -13,13 +13,15 @@ together.
 from dataclasses import MISSING, dataclass
 from typing import Any, Dict, List, Optional
 import dataclasses
+import logging
 
 # Third Party
 import pytest
 
 # Local
-from fms_dgt.base.block import Block
-from fms_dgt.base.data_objects import BlockData, DataPoint
+from fms_dgt.base.block import Block, ValidatorBlock
+from fms_dgt.base.data_objects import BlockData, DataPoint, ValidatorBlockData
+from fms_dgt.base.telemetry import _NoOpSpanWriter
 from fms_dgt.utils import from_dataclass, to_dataclass
 
 
@@ -49,15 +51,16 @@ class _SamplePoint(DataPoint):
 
     Inherits ``task_name`` / ``is_seed`` from :class:`DataPoint` and declares
     the fields touched by the block's default ``output_map`` echo (``score``,
-    ``labels``, ``tag``, ``store_names``) plus extra fields that the tests
-    aim nested writes at (``tags``, ``annotations``, ``metadata``).
+    ``labels``, ``tag``) plus extra fields that the tests aim nested writes at
+    (``tags``, ``annotations``, ``metadata``). ``store_names`` is intentionally
+    omitted: it is framework-reserved bookkeeping and must never appear in any
+    default output_map.
     """
 
     question: str = ""
     score: Optional[float] = None
     labels: Optional[Dict[str, Any]] = None
     tag: Optional[str] = None
-    store_names: Optional[List[str]] = None
     tags: Optional[List[str]] = None
     annotations: Optional[Dict[str, Any]] = None
     metadata: Optional[Dict[str, Any]] = None
@@ -422,6 +425,87 @@ def test_transform_output_dataclass_nested_read_from_dict_inp():
     block.transform_output(inp, {"result.scores[0].value": "metadata.top_score"})
 
     assert src.metadata == {"top_score": 0.7}
+
+
+# ===========================================================================
+#       transform_output — framework-bookkeeping exclusion (regression)
+# ===========================================================================
+def test_default_map_excludes_store_names_on_dataclass_src():
+    """Framework-reserved ``store_names`` must not appear in the default
+    output_map, so a user ``DataPoint`` that omits the field is not required
+    to declare it just to satisfy the echo. Regression for the
+    direct-call-on-dataclass-list failure documented at
+    ``.claude/discussions/transform-output-bookkeeping-fields-leak.md``.
+    """
+
+    @dataclass
+    class _UserDP(DataPoint):
+        payload: str = ""
+
+    @dataclass(kw_only=True)
+    class _ToyData(ValidatorBlockData):
+        payload: str = ""
+
+    class _ToyValidator(ValidatorBlock):
+        DATA_TYPE = _ToyData
+
+        def __init__(self):
+            self._name = "toy"
+            self._block_type = "test"
+            self._input_map = None
+            self._output_map = None
+            self._req_args = []
+            self._opt_args = [
+                f.name for f in dataclasses.fields(_ToyData) if f.default is not dataclasses.MISSING
+            ]
+            self._filter_invalids = True
+            # Bypass datastore / profiling machinery for this unit.
+            self._datastores = None
+            self.profiler_data = {"executions": []}
+            self._builder_name = None
+            self._span_writer = _NoOpSpanWriter()
+            self._logger = logging.getLogger(f"fms_dgt.block.{self._name}")
+
+        def _validate(self, instance):
+            return instance.payload != "", None
+
+    v = _ToyValidator()
+    out = list(v([_UserDP(task_name="t", payload="hello"), _UserDP(task_name="t", payload="")]))
+
+    assert len(out) == 1
+    assert out[0].payload == "hello"
+
+
+def test_default_map_silent_skip_for_unknown_is_valid_field():
+    """Framework-synthesized default-map entries that target a field
+    ``src_data`` does not declare are silently skipped. User-declared
+    ``output_map`` entries remain strict (see
+    ``test_transform_output_dataclass_undeclared_destination_raises``).
+    """
+    block = _DataclassBlock()  # DATA_TYPE=_SampleBlockData, no is_valid field
+    src = _SamplePoint(task_name="t", question="q")
+    inp = _dc_inp(src, score=0.5)
+
+    # Default map echoes score/labels/tag. No user-declared map given, so the
+    # absence of any field on _SamplePoint that the block might try to write
+    # must not raise. (Happy-path existing tests already cover this shape, but
+    # this pins the contract explicitly.)
+    out = block.transform_output(inp, {})
+    assert out is src
+    assert out.score == 0.5
+
+
+def test_user_declared_typo_still_raises_after_fix():
+    """Fix must not re-introduce silent-skip for caller typos. Guards against
+    over-broadening the dataclass-branch strict check.
+    """
+    block = _DataclassBlock()
+    src = _SamplePoint(task_name="t", question="q")
+    inp = _dc_inp(src, score=0.5)
+
+    # User-declared path-side typo: strict-raise preserved.
+    with pytest.raises(ValueError):
+        block.transform_output(inp, {"score": "nonexistent_target"})
 
 
 # ===========================================================================


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it

Direct calls that pass user dataclasses to a Block (e.g. a ValidatorBlock invoked in a databuilder's generation loop) raised `ValueError: Dataclass ... has no field 'store_names'` on row 1. The postprocessor path masked it by always feeding dicts, where the default-map echo was a no-op write.

### Root cause
`_get_default_map` filtered only `SRC_DATA`, letting `store_names` (and, for validators, `is_valid` / `metadata`) into the default output_map. After 7659d86 removed the `hasattr` silent-skip, framework-synthesized default entries now tripped the strict check on any src_data that didn't declare them.

### Fix
- constants: add STORE_NAMES_KEY alongside STORE_NAME_KEY; thread it through all 7 producer sites (base/databuilder/base.py, magpie, instructlab/knowledge, instructlab/skills x4) so the bare "store_names" literal lives in one place.
- block: add _FRAMEWORK_FIELDS = frozenset({_SRC_DATA, STORE_NAMES_KEY}) and exclude the full set from _get_default_map. In transform_output's dataclass branch, distinguish caller-declared keys from framework-synthesized defaults: strict-raise preserved for user typos (the 7659d86 intent), silent-skip restored narrowly for default-map entries targeting fields src_data doesn't declare.


### Tests

drop store_names from _SamplePoint (existed only to absorb the buggy echo); add regression coverage for the direct-call path, the is_valid default-skip contract, and the user-typo strict-raise guard.

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
