### PR TITLE
fix(block): make _get_default_map direction-aware to preserve store_names supply

### DIFF
--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -349,7 +349,7 @@ class Block:
         if isinstance(inp_obj, (dict, pd.DataFrame, Dataset)):
             # NOTE: we flip this here because from a DGT pipeline, the input map goes from UserData -> BlockData
             data_type_map = {
-                **{v: k for k, v in self._get_default_map(inp).items()},
+                **{v: k for k, v in self._get_default_map(inp, direction="in").items()},
                 **{v: k for k, v in input_map.items()},
             }
 
@@ -410,7 +410,7 @@ class Block:
         # declare. A user DataPoint that omits e.g. ``is_valid`` should not
         # raise when a ValidatorBlock's default echo tries to write it back.
         user_declared = set(output_map)
-        output_map = {**self._get_default_map(src_data), **output_map}
+        output_map = {**self._get_default_map(src_data, direction="out"), **output_map}
 
         if is_dataclass(src_data):
             for k, path in output_map.items():
@@ -452,14 +452,39 @@ class Block:
 
         return src_data
 
-    def _get_default_map(self, data: Dict | BlockData):
+    def _get_default_map(self, data: Dict | BlockData, *, direction: str = "out"):
+        """Return the identity default map for ``transform_input`` / ``transform_output``.
+
+        The ``direction`` flag controls whether framework bookkeeping fields
+        (``_FRAMEWORK_FIELDS``) are excluded:
+
+        - ``direction="out"`` excludes them. The output-side echo would
+          otherwise try to write ``store_names`` back onto a user
+          ``DataPoint`` that does not declare it, triggering the
+          strict-raise in ``_to_dataclass``.
+        - ``direction="in"`` keeps them. Framework bookkeeping like
+          ``store_names`` is **supplied on the way in** by the caller
+          (``execute_postprocessing`` injects it into each row's dict;
+          direct in-loop callers hand-build dicts that include it). The
+          input-side default map is the route by which that injected value
+          lands on the block-side ``BlockData`` instance where
+          ``Block.save_data`` reads it for routing. Excluding framework
+          fields here silently severs that route, and ``save_data`` finds
+          ``store_names=None`` on every rejected instance, so nothing gets
+          persisted.
+
+        The asymmetry is intentional: bookkeeping fields flow in, never
+        flow back out, and the two directions must be filtered differently.
+        """
         # if DATA_TYPE is not provided, assume it maps to the input
         if is_dataclass(self.DATA_TYPE):
             fields = dataclasses.fields(self.DATA_TYPE)
         else:
             fields = data.keys() if isinstance(data, dict) else dataclasses.fields(data)
         fields = [f if isinstance(f, str) else f.name for f in fields]
-        return {f: f for f in fields if f not in _FRAMEWORK_FIELDS}
+        if direction == "out":
+            return {f: f for f in fields if f not in _FRAMEWORK_FIELDS}
+        return {f: f for f in fields if f != _SRC_DATA}
 
     # ===========================================================================
     #                       MAIN FUNCTIONS

--- a/tests/base/test_block.py
+++ b/tests/base/test_block.py
@@ -624,3 +624,57 @@ def test_transform_input_missing_required_arg_raises_valueerror():
 
     with pytest.raises(ValueError):
         block.transform_input(row, None)
+
+
+# ===========================================================================
+#       transform_input — framework-bookkeeping supply route (regression)
+# ===========================================================================
+def test_transform_input_default_map_carries_store_names_to_block_data():
+    """Framework bookkeeping (``store_names``) injected on the input dict
+    must reach the block-side ``BlockData`` instance via the default map.
+
+    Regression for the asymmetric-direction fix: the output-side exclusion
+    must not also strip ``store_names`` on the input side, otherwise
+    ``Block.save_data`` finds ``store_names=None`` on every rejected
+    instance and silently drops persistence (rejection log fires, but no
+    file is written under the per-block datastore).
+
+    See ``.claude/discussions/transform-output-bookkeeping-fields-leak.md``
+    "Correction" section.
+    """
+    block = _InputBlock()
+    row = {
+        "question_text": "q",
+        "score": 0.7,
+        "labels": {"primary": "safe"},
+        "tag": "x",
+        "store_names": ["per_task_store"],
+    }
+
+    out = block.transform_input(row, block._input_map)
+
+    # The whole point of the supply route: caller-injected store_names
+    # lands on the constructed BlockData where save_data can read it.
+    assert out.store_names == ["per_task_store"]
+    # Other declared fields still flow as before.
+    assert out.score == 0.7
+    assert out.labels == {"primary": "safe"}
+    assert out.tag == "x"
+
+
+def test_transform_output_default_map_still_skips_store_names():
+    """Direction asymmetry guard: the output-side default map must continue
+    to exclude ``store_names`` even though the input side carries it. A
+    user ``DataPoint`` that does not declare ``store_names`` must survive
+    the echo without raising.
+    """
+    src = _SamplePoint(task_name="t", question="q")  # no store_names field
+    block = _DataclassBlock()
+    inp = _dc_inp(src, score=0.5)
+
+    # Default output_map only — no user-declared keys. Must not raise on
+    # the absent store_names field on _SamplePoint.
+    out = block.transform_output(inp, {})
+
+    assert out is src
+    assert out.score == 0.5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

## What this PR does / why we need it

  The previous symmetric exclusion of _FRAMEWORK_FIELDS from _get_default_map
  fixed the transform_output crash on user DataPoints that don't declare
  store_names, but it also stripped store_names from transform_input's default
  map — silently severing the route by which caller-injected routing metadata
  reaches the block-side BlockData. Block.save_data then found store_names=None
  on every ValidatorBlock reject and dropped them without persisting.

  Split the filter by direction: transform_input keeps framework fields so
  injected store_names lands on the BlockData where save_data reads it;
  transform_output continues to exclude them so the echo cannot write back onto
  SRC_DATA dataclasses that don't declare the field.

  Adds two regression tests pinning the asymmetry, and a Correction section in
  the design discussion documenting why the first attempt was incomplete.

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
