### PR TITLE
feat(magpie,block,openai): rewrite distance dedup, fix span writer propagation, add reasoning_effort

### DIFF
--- a/fms_dgt/base/block.py
+++ b/fms_dgt/base/block.py
@@ -227,6 +227,8 @@ class Block:
     @span_writer.setter
     def span_writer(self, writer) -> None:
         self._span_writer = writer
+        for block in self._blocks:
+            block.span_writer = writer
 
     @property
     def input_map(self) -> List | Dict:

--- a/fms_dgt/base/databuilder/base.py
+++ b/fms_dgt/base/databuilder/base.py
@@ -202,6 +202,26 @@ class DataBuilder:
         self._span_writer = writer
         for block in self._blocks:
             block.span_writer = writer
+        if not isinstance(writer, _NoOpSpanWriter):
+            self._warn_noop_writers(self._blocks)
+
+    def _warn_noop_writers(self, blocks) -> None:
+        """Warn for any block in the tree that still holds a no-op writer.
+
+        This fires after the recursive setter has run, so any surviving no-op
+        belongs to a block whose author stored a child in a plain attribute
+        instead of registering it in self._blocks.
+        """
+        for block in blocks:
+            if isinstance(block._span_writer, _NoOpSpanWriter):
+                self._logger.warning(
+                    "Block '%s' (type=%s) still holds a _NoOpSpanWriter after "
+                    "telemetry wiring — its child blocks may not be registered "
+                    "in self._blocks and will emit no telemetry spans.",
+                    block.name,
+                    block.block_type,
+                )
+            self._warn_noop_writers(block._blocks)
 
     # ===========================================================================
     #                       HELPER FUNCTIONS
@@ -229,7 +249,6 @@ class DataBuilder:
         if len(self._config.blocks) != len([b.get("name") for b in self._config.blocks]):
             raise ValueError(f"Duplicate block in '{self.name}' data builder detected")
 
-        # TODO: need to handle nested blocks
         for block_configuration in self._config.blocks:
             # Verify "name" and "type" properties are provided for each block
             for mandatory_property in [NAME_KEY, TYPE_KEY]:

--- a/fms_dgt/core/blocks/llm/openai.py
+++ b/fms_dgt/core/blocks/llm/openai.py
@@ -81,6 +81,7 @@ class OpenAIChatCompletionParameters(Parameters):
     response_format: Dict | NotGiven = NOT_GIVEN
     top_logprobs: int | NotGiven = NOT_GIVEN
     extra_body: Dict | NotGiven = NOT_GIVEN
+    reasoning_effort: Literal["none", "low", "medium", "high"] | NotGiven = NOT_GIVEN
 
     @classmethod
     def from_dict(cls, params: Dict):

--- a/fms_dgt/public/blocks/magpie/distance/block.py
+++ b/fms_dgt/public/blocks/magpie/distance/block.py
@@ -3,11 +3,10 @@
 
 # Standard
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
-import uuid
+from typing import Any, Dict, List, Optional, Tuple, Union
+import hashlib
 
 # Third Party
-from datasets import Dataset
 from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 import numpy as np
@@ -44,15 +43,55 @@ class MagpieDistanceBlockData(BlockData):
 
 @register_block("magpie_distance")
 class MagpieDistance(Block):
-    r"""Class for Magpie Distance based duplicate identification
+    r"""Class for Magpie Distance based duplicate identification.
+
+    Embeds every input, finds near-duplicates via cosine similarity, and tags
+    each row with the *canonical* member of its duplicate cluster
+    (``min_similar_uuid``). A downstream ``magpie_filter`` keeps a row only when
+    its ``min_similar_uuid`` points to itself, so each duplicate cluster
+    collapses to a single survivor.
+
+    The canonical member is the one with the lexicographically smallest ``id``
+    in the cluster. Because ``id`` is a stable property of the row (and is
+    derived from a content hash when not supplied), the surviving set does not
+    depend on the order in which inputs are presented.
+
+    Two search backends are available:
+
+    * **matmul** (default for the exact path) computes cosine similarity with a
+      batched matrix multiply on the device that ``SentenceTransformer`` picks
+      (GPU when available, else CPU). This is exact and needs no GPU build of
+      FAISS.
+    * **faiss** (HNSW / IVF) is an approximate escape hatch for very large ``N``
+      on CPU-only machines, where the exact O(N^2) path is impractical.
 
     Args:
-        sentence_model (Optional[str]): sentence model to use for encoding. Defaults to `sentence-transformers/all-mpnet-base-v2`
-        distance_threshold (Optional[float]): similarity measure in distance. Defaults to `0.05`
-        search_space_size (Optional[int]): FAISS search space size. Defaults to `500`
-        search_batch_size (Optional[int]): FAISS search batch size. Defaults to `1024`
-        encoding_batch_size (Optional[int]): number of entries to encode in a batch. Defaults to `65536`
-
+        sentence_model (str): sentence model to use for encoding. Defaults to
+            ``sentence-transformers/all-mpnet-base-v2``.
+        distance_threshold (float): squared-L2 distance cutoff below which two
+            inputs are considered duplicates (smaller distance == more similar).
+            Defaults to ``0.05``. Internally, embeddings are L2-normalized and
+            this distance is converted to an equivalent cosine-similarity cutoff
+            via ``cosine = 1 - distance / 2`` (so ``0.05`` -> cosine ``0.975``);
+            the public knob keeps its original distance units and meaning.
+        index_type (str): one of ``auto`` | ``flat`` | ``hnsw`` | ``ivf``.
+            ``auto`` (default) picks exact matmul when it fits the device and an
+            approximate FAISS index otherwise.
+        max_rows_cpu (int): in ``auto`` mode on a CPU-only device, the largest
+            number of input rows (``N``) handled by the exact all-pairs search.
+            Above this, ``auto`` falls back to an approximate FAISS index because
+            the exact path is O(N^2) and impractical on CPU at scale. Defaults to
+            ``50_000``.
+        max_rows_gpu (int): in ``auto`` mode, the largest number of input rows
+            (``N``) handled by the exact all-pairs search even when a GPU is
+            available. Above this, ``auto`` falls back to an approximate FAISS
+            index. Defaults to ``500_000``.
+        search_space_size (int): retained for backward compatibility; unused by
+            the threshold-based duplicate detection. Defaults to ``500``.
+        search_batch_size (int): number of query rows per search batch. Defaults
+            to ``1024``.
+        encoding_batch_size (int): number of entries to encode in a batch.
+            Defaults to ``65536``.
 
     .. code-block:: python
 
@@ -81,6 +120,9 @@ class MagpieDistance(Block):
         self,
         sentence_model: str = "sentence-transformers/all-mpnet-base-v2",
         distance_threshold: float = 0.05,
+        index_type: str = "auto",
+        max_rows_cpu: int = 50000,
+        max_rows_gpu: int = 500000,
         search_space_size: int = 500,
         search_batch_size: int = 1024,
         encoding_batch_size: int = 65536,
@@ -104,8 +146,23 @@ class MagpieDistance(Block):
         # Initialize parent
         super().__init__(input_map=input_map, output_map=output_map, **kwargs)
 
-        # Set additional necessary variables
+        # The public knob is a squared-L2 distance (smaller == more similar).
+        # Embeddings are L2-normalized, so squared-L2 and cosine are equivalent
+        # (``squared_l2 = 2 - 2 * cosine``); convert once to a cosine cutoff that
+        # the search paths use directly.
         self._distance_threshold = distance_threshold
+        self._similarity_threshold = 1.0 - (distance_threshold / 2.0)
+
+        index_type = index_type.lower()
+        if index_type not in ("auto", "flat", "hnsw", "ivf"):
+            raise ValueError(
+                f"index_type must be one of 'auto', 'flat', 'hnsw', 'ivf'; got {index_type!r}"
+            )
+        self._index_type = index_type
+        self._max_rows_cpu = max_rows_cpu
+        self._max_rows_gpu = max_rows_gpu
+
+        # Retained for backward compatibility; not used by the duplicate logic.
         self._search_space_size = search_space_size
         self._search_batch_size = search_batch_size
         self._encoding_batch_size = encoding_batch_size
@@ -116,155 +173,246 @@ class MagpieDistance(Block):
 
         self.logger.info("The model is loaded on device: %s", self._model.device)
 
-    def index(self, dataset: Dataset):
-        inputs = dataset["text"]
+    # ------------------------------------------------------------------
+    #  Embedding
+    # ------------------------------------------------------------------
+    def embed(self, texts: List[str]) -> torch.Tensor:
+        """Encode ``texts`` into L2-normalized embeddings on the model device.
 
-        # Encode the sentences in the dataset into vectors
-        embeddings = []
-        for i in range(0, len(inputs), self._encoding_batch_size):
-            batch_sentences = inputs[i : i + self._encoding_batch_size]
-            batch_embeddings = self._model.encode(
-                batch_sentences, convert_to_tensor=True, show_progress_bar=True
+        Returns a contiguous ``float32`` tensor of shape ``(N, d)`` left on the
+        model's device (GPU when available) so the exact matmul path can run
+        there without an extra host transfer.
+        """
+        chunks: List[torch.Tensor] = []
+        for i in range(0, len(texts), self._encoding_batch_size):
+            batch = texts[i : i + self._encoding_batch_size]
+            emb = self._model.encode(
+                batch,
+                convert_to_tensor=True,
+                normalize_embeddings=True,
+                show_progress_bar=True,
             )
-            embeddings.append(batch_embeddings.cpu().numpy())
+            chunks.append(emb.to(dtype=torch.float32))
+        return torch.cat(chunks, dim=0).contiguous()
 
-        # Concatenate the embeddings
-        embeddings = np.concatenate(embeddings, axis=0)
+    # ------------------------------------------------------------------
+    #  Backend selection
+    # ------------------------------------------------------------------
+    def _select_backend(self, n: int) -> str:
+        """Resolve ``index_type='auto'`` to a concrete backend for ``n`` rows.
 
-        # Add the encoded vectors to the dataset
-        dataset = dataset.add_column("embeddings", embeddings.tolist())
+        Returns ``"matmul"`` for the exact path or ``"hnsw"`` for the
+        approximate path. Explicit ``index_type`` values are honored as-is
+        (``flat`` maps to ``matmul``).
+        """
+        if self._index_type == "flat":
+            return "matmul"
+        if self._index_type in ("hnsw", "ivf"):
+            return self._index_type
 
-        # Build the Faiss index on the dataset
-        dataset.add_faiss_index(column="embeddings", index_name="embeddings")
+        # auto
+        on_gpu = self._model.device.type == "cuda"
+        max_rows = self._max_rows_gpu if on_gpu else self._max_rows_cpu
+        if n <= max_rows and n <= self._max_rows_gpu:
+            return "matmul"
 
-        return dataset, embeddings
+        backend = "hnsw"
+        self.logger.warning(
+            "magpie_distance: N=%d on device=%s exceeds the exact-search limit "
+            "(%d rows); routing to approximate '%s' index. Set index_type "
+            "explicitly to override.",
+            n,
+            self._model.device.type,
+            max_rows,
+            backend,
+        )
+        return backend
 
-    def compute(
+    # ------------------------------------------------------------------
+    #  Exact search (matmul)
+    # ------------------------------------------------------------------
+    def _search_matmul(self, embeddings: torch.Tensor) -> List[Tuple[List[int], List[float]]]:
+        """Exact cosine duplicate search via batched matrix multiply.
+
+        For each row, returns ``(neighbor_indices, neighbor_similarities)`` for
+        all other rows whose cosine similarity is at or above the threshold.
+        """
+        n = embeddings.shape[0]
+        results: List[Tuple[List[int], List[float]]] = [([], []) for _ in range(n)]
+        for start in tqdm(range(0, n, self._search_batch_size)):
+            end = min(start + self._search_batch_size, n)
+            # (B, N) cosine similarity slab on the active device.
+            sims = embeddings[start:end] @ embeddings.T
+            mask = sims >= self._similarity_threshold
+            rows, cols = torch.nonzero(mask, as_tuple=True)
+            scores = sims[rows, cols].cpu().numpy()
+            rows = rows.cpu().numpy()
+            cols = cols.cpu().numpy()
+            for r, c, s in zip(rows, cols, scores):
+                q = start + int(r)
+                c = int(c)
+                if c != q:
+                    results[q][0].append(c)
+                    results[q][1].append(float(s))
+        return results
+
+    # ------------------------------------------------------------------
+    #  Approximate search (FAISS HNSW / IVF) -- escape hatch
+    # ------------------------------------------------------------------
+    def _search_faiss(
+        self, embeddings: torch.Tensor, backend: str
+    ) -> List[Tuple[List[int], List[float]]]:
+        """Approximate cosine duplicate search via a FAISS HNSW/IVF index.
+
+        Used only for very large ``N`` on CPU-only machines, where the exact
+        O(N^2) matmul is impractical. ``faiss`` is imported lazily so it never
+        loads on the default (exact) path.
+        """
+        # Third Party
+        import faiss  # noqa: PLC0415 -- lazy: keep faiss off the default code path
+
+        vectors = embeddings.cpu().numpy().astype(np.float32)
+        n, d = vectors.shape
+        # Inner product on unit vectors == cosine similarity.
+        if backend == "ivf":
+            nlist = max(1, min(int(np.sqrt(n)), n))
+            quantizer = faiss.IndexFlatIP(d)
+            index = faiss.IndexIVFFlat(quantizer, d, nlist, faiss.METRIC_INNER_PRODUCT)
+            index.train(vectors)
+            index.nprobe = min(nlist, 16)
+        else:  # hnsw
+            index = faiss.IndexHNSWFlat(d, 32, faiss.METRIC_INNER_PRODUCT)
+            index.hnsw.efSearch = 64
+        index.add(vectors)
+        self.logger.info(
+            "magpie_distance: built approximate FAISS '%s' index over %d vectors.",
+            backend,
+            n,
+        )
+
+        # range_search returns all neighbors with inner product >= threshold.
+        results: List[Tuple[List[int], List[float]]] = [([], []) for _ in range(n)]
+        for start in tqdm(range(0, n, self._search_batch_size)):
+            end = min(start + self._search_batch_size, n)
+            lims, dists, idxs = index.range_search(
+                vectors[start:end], float(self._similarity_threshold)
+            )
+            for local_q in range(end - start):
+                q = start + local_q
+                sl = slice(lims[local_q], lims[local_q + 1])
+                for c, s in zip(idxs[sl], dists[sl]):
+                    if int(c) != q:
+                        results[q][0].append(int(c))
+                        results[q][1].append(float(s))
+        return results
+
+    # ------------------------------------------------------------------
+    #  Tagging
+    # ------------------------------------------------------------------
+    def _tag_duplicates(
         self,
-        dataset: Dataset,
-        embeddings: np.ndarray,
+        neighbors: List[Tuple[List[int], List[float]]],
+        ids: List[str],
         instances: List[MagpieDistanceBlockData],
-    ):
+    ) -> None:
+        """Populate ``magpie_tags`` with the order-independent dedup result.
 
-        n_batches = (len(dataset) + self._search_batch_size - 1) // self._search_batch_size
+        The canonical survivor of a cluster is the row with the smallest ``id``
+        among the cluster. A row keeps itself iff it *is* that canonical row.
+        ``min_neighbor_distance`` is the squared-L2 distance to the nearest
+        duplicate (converted from cosine similarity via ``2 - 2 * cosine``).
+        """
+        for i, (dup_indices, dup_sims) in enumerate(neighbors):
+            if dup_indices:
+                cluster_ids = [ids[i]] + [ids[j] for j in dup_indices]
+                min_similar_uuid = min(cluster_ids)
+                repeat_count = len(dup_indices)
+                # Convert max cosine similarity back to squared-L2 distance to
+                # match the original field's units (smaller == more similar).
+                min_neighbor_distance = 2.0 - 2.0 * max(dup_sims)
+            else:
+                min_similar_uuid = None
+                repeat_count = 0
+                min_neighbor_distance = None
 
-        for batch_idx in tqdm(range(n_batches)):
-            start_idx = batch_idx * self._search_batch_size
-            end_idx = min((batch_idx + 1) * self._search_batch_size, len(dataset))
+            if not instances[i].magpie_tags:
+                instances[i].magpie_tags = {}
 
-            batch_indices = list(range(start_idx, end_idx))
+            instances[i].magpie_tags["min_neighbor_distance"] = min_neighbor_distance
+            instances[i].magpie_tags["repeat_count"] = repeat_count
+            instances[i].magpie_tags["min_similar_uuid"] = min_similar_uuid
 
-            # Obtain the embeddings for the current batch
-            batch_embeddings = embeddings[batch_indices]
-
-            # Search for the most similar examples
-            search_results = dataset.search_batch(
-                index_name="embeddings",
-                queries=batch_embeddings,
-                k=min(self._search_space_size, len(dataset)),
-            )
-            total_scores = search_results.total_scores
-            total_indices = search_results.total_indices
-
-            for idx, indices in enumerate(total_indices):
-                scores = total_scores[idx]
-                indices = total_indices[idx]
-                min_distance = float(scores[1])  # should exclude itself
-                dataset[start_idx + idx]["min_distance"] = min_distance
-
-                filtered_indices = [
-                    index
-                    for index, score in zip(indices, scores)
-                    if score < self._distance_threshold
-                ]
-                # Should remove itself
-                filtered_indices = [index for index in filtered_indices if index != start_idx + idx]
-
-                if len(filtered_indices) == 0:
-                    repeat_count = 0
-                    min_similar_uuid = None
-                    dataset[start_idx + idx]["repeat_count"] = repeat_count
-                    dataset[start_idx + idx]["min_similar_uuid"] = min_similar_uuid
-                else:
-                    min_similar_uuidx = int(min(filtered_indices))
-                    if min_similar_uuidx >= start_idx + idx:
-                        min_similar_uuid = dataset[start_idx + idx]["id"]
-                    else:
-                        min_similar_uuid = dataset[min_similar_uuidx]["id"]
-
-                    repeat_count = len(filtered_indices)
-
-                    dataset[start_idx + idx]["repeat_count"] = repeat_count
-                    dataset[start_idx + idx]["min_similar_uuid"] = min_similar_uuid
-
-                # Initialize results container, if necessary
-                if not instances[start_idx + idx].magpie_tags:
-                    instances[start_idx + idx].magpie_tags = {}
-
-                # Store results
-                instances[start_idx + idx].magpie_tags["min_neighbor_distance"] = min_distance
-                instances[start_idx + idx].magpie_tags["repeat_count"] = repeat_count
-                instances[start_idx + idx].magpie_tags["min_similar_uuid"] = min_similar_uuid
-
+    # ------------------------------------------------------------------
+    #  Entry point
+    # ------------------------------------------------------------------
     def execute(self, inputs: List[MagpieDistanceBlockData]) -> List[MagpieDistanceBlockData]:
         # Cast to list, if necessary
         inputs = [entry for entry in inputs] if isinstance(inputs, map) else inputs
 
-        # Convert to HuggingFace dataset object
-        data = []
-        for entry in inputs:
-            # Add "id" field, if not present already
-            if entry.id is None:
-                entry.id = str(uuid.uuid4())
+        texts, ids = self._prepare(inputs)
+        if not texts:
+            return inputs
 
-            # Initialize record
-            record = {"id": entry.id}
+        embeddings = self.embed(texts)
+        backend = self._select_backend(len(texts))
+        if backend == "matmul":
+            neighbors = self._search_matmul(embeddings)
+        else:
+            neighbors = self._search_faiss(embeddings, backend)
 
-            # Flatten input, if in Multi-turn settings
-            if entry.magpie_mt_input:
-                user_utterance_texts = []
-                for utterance in entry.magpie_mt_input:
-                    # Identify role field
-                    if "from" in utterance:
-                        role_field = "from"
-                    elif "role" in utterance:
-                        role_field = "role"
-                    elif "speaker" in utterance:
-                        role_field = "speaker"
-                    else:
-                        raise ValueError(
-                            "\"magpie_mt_input\" should have a 'from' field or a 'role' field or a 'speaker' field to signify whether it was a user or assistant utterance"
-                        )
-
-                    # Identify text/content field
-                    if "value" in utterance:
-                        txt_field = "value"
-                    elif "content" in utterance:
-                        txt_field = "content"
-                    elif "text" in utterance:
-                        txt_field = "text"
-                    else:
-                        # Skipping messages without content
-                        continue
-                    if utterance[role_field] == "user":
-                        user_utterance_texts.append(utterance[txt_field])
-
-                record["text"] = ("\n\n".join(user_utterance_texts)).strip()
-            else:
-                record["text"] = entry.magpie_input.strip()
-
-            # Add record
-            data.append(record)
-
-        # Run indexing and dedup, only if data is available
-        if data:
-            dataset = Dataset.from_list(data)
-
-            # Index data
-            dataset, embeddings = self.index(dataset)
-
-            # Add similarity scores
-            self.compute(dataset, embeddings=embeddings, instances=inputs)
-
-        # Return
+        self._tag_duplicates(neighbors, ids, inputs)
         return inputs
+
+    # ------------------------------------------------------------------
+    #  Helpers
+    # ------------------------------------------------------------------
+    def _prepare(self, inputs: List[MagpieDistanceBlockData]) -> Tuple[List[str], List[str]]:
+        """Flatten each entry to its text and resolve a stable id.
+
+        Missing ids are derived from an md5 of the text so they are stable
+        across runs (matching the annotate pipeline's id convention), rather
+        than a random UUID.
+        """
+        texts: List[str] = []
+        ids: List[str] = []
+        for entry in inputs:
+            text = self._extract_text(entry)
+            if entry.id is None:
+                entry.id = hashlib.md5(text.encode("utf-8")).hexdigest()
+            texts.append(text)
+            ids.append(entry.id)
+        return texts, ids
+
+    @staticmethod
+    def _extract_text(entry: MagpieDistanceBlockData) -> str:
+        """Return the user-side text for an entry (single- or multi-turn)."""
+        if entry.magpie_mt_input:
+            user_utterance_texts = []
+            for utterance in entry.magpie_mt_input:
+                # Identify role field
+                if "from" in utterance:
+                    role_field = "from"
+                elif "role" in utterance:
+                    role_field = "role"
+                elif "speaker" in utterance:
+                    role_field = "speaker"
+                else:
+                    raise ValueError(
+                        "\"magpie_mt_input\" should have a 'from' field or a 'role' field or a 'speaker' field to signify whether it was a user or assistant utterance"
+                    )
+
+                # Identify text/content field
+                if "value" in utterance:
+                    txt_field = "value"
+                elif "content" in utterance:
+                    txt_field = "content"
+                elif "text" in utterance:
+                    txt_field = "text"
+                else:
+                    # Skipping messages without content
+                    continue
+                if utterance[role_field] == "user":
+                    user_utterance_texts.append(utterance[txt_field])
+
+            return ("\n\n".join(user_utterance_texts)).strip()
+        return entry.magpie_input.strip()

--- a/tests/public/blocks/magpie/__init__.py
+++ b/tests/public/blocks/magpie/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/public/blocks/magpie/test_distance.py
+++ b/tests/public/blocks/magpie/test_distance.py
@@ -1,0 +1,116 @@
+# Copyright The DiGiT Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :class:`MagpieDistance` dedup behavior.
+
+These tests exercise the duplicate-detection and tagging logic without loading
+the real sentence-transformer model: the block's ``embed`` method and model are
+stubbed so embeddings are deterministic and the tests stay fast and offline.
+The surviving-set assertion is the regression test for order-independence.
+"""
+
+# Standard
+import hashlib
+
+# Third Party
+import pytest
+import torch
+
+# Local
+from fms_dgt.public.blocks.magpie.distance.block import (
+    MagpieDistance,
+    MagpieDistanceBlockData,
+)
+
+
+def _make_block(monkeypatch, text_to_vec, **kwargs):
+    """Build a MagpieDistance whose embeddings come from ``text_to_vec``.
+
+    Avoids constructing the real SentenceTransformer (no __init__ network/model
+    load) and replaces ``embed`` with a deterministic lookup.
+    """
+    block = MagpieDistance.__new__(MagpieDistance)
+    # Minimal state the methods under test rely on.
+    block._similarity_threshold = kwargs.get("similarity_threshold", 0.975)
+    block._index_type = kwargs.get("index_type", "flat")
+    block._max_rows_cpu = kwargs.get("max_rows_cpu", 50_000)
+    block._max_rows_gpu = kwargs.get("max_rows_gpu", 500_000)
+    block._search_batch_size = kwargs.get("search_batch_size", 1024)
+    block._model = type("_M", (), {"device": torch.device("cpu")})()
+
+    def fake_embed(texts):
+        vecs = torch.tensor([text_to_vec[t] for t in texts], dtype=torch.float32)
+        return torch.nn.functional.normalize(vecs, dim=1)
+
+    monkeypatch.setattr(block, "embed", fake_embed)
+    return block
+
+
+def _survivors(instances):
+    """Ids whose tag points to themselves => kept by the downstream filter."""
+    return {e.id for e in instances if e.magpie_tags.get("min_similar_uuid") in (None, e.id)}
+
+
+# Two near-identical "France capital" vectors, two near-identical "photosynthesis"
+# vectors, plus a unique one. Within-cluster cosine ~1.0; across-cluster ~0.
+_VECS = {
+    "france_a": [1.0, 0.0, 0.0],
+    "france_b": [0.999, 0.04, 0.0],
+    "photo_a": [0.0, 1.0, 0.0],
+    "photo_b": [0.0, 0.999, 0.04],
+    "unique": [0.0, 0.0, 1.0],
+}
+
+
+def _entries(order):
+    return [MagpieDistanceBlockData(SRC_DATA={}, magpie_input=t, id=t) for t in order]
+
+
+def test_clusters_collapse_to_one_survivor(monkeypatch):
+    block = _make_block(monkeypatch, _VECS)
+    order = ["france_a", "france_b", "photo_a", "photo_b", "unique"]
+    out = block.execute(_entries(order))
+    survivors = _survivors(out)
+    # One survivor per cluster + the unique row = 3 total.
+    assert survivors == {"france_a", "photo_a", "unique"}
+
+
+def test_order_independence(monkeypatch):
+    """Shuffling the input must not change which rows survive."""
+    order_a = ["france_a", "france_b", "photo_a", "photo_b", "unique"]
+    order_b = ["unique", "photo_b", "france_b", "photo_a", "france_a"]
+
+    block_a = _make_block(monkeypatch, _VECS)
+    block_b = _make_block(monkeypatch, _VECS)
+    survivors_a = _survivors(block_a.execute(_entries(order_a)))
+    survivors_b = _survivors(block_b.execute(_entries(order_b)))
+
+    assert survivors_a == survivors_b == {"france_a", "photo_a", "unique"}
+
+
+def test_threshold_separates_similar_from_distinct(monkeypatch):
+    block = _make_block(monkeypatch, _VECS)
+    out = block.execute(_entries(list(_VECS)))
+    tags = {e.id: e.magpie_tags for e in out}
+    # Near-identical pair flagged as duplicates of each other.
+    assert tags["france_b"]["repeat_count"] >= 1
+    # Distinct row has no duplicates.
+    assert tags["unique"]["repeat_count"] == 0
+    assert tags["unique"]["min_similar_uuid"] is None
+
+
+def test_deterministic_md5_id_when_missing(monkeypatch):
+    block = _make_block(monkeypatch, {"hello world": [1.0, 0.0, 0.0]})
+    entry = MagpieDistanceBlockData(SRC_DATA={}, magpie_input="hello world", id=None)
+    block.execute([entry])
+    expected = hashlib.md5("hello world".encode("utf-8")).hexdigest()
+    assert entry.id == expected
+
+
+def test_legacy_distance_threshold_maps_to_cosine():
+    # Construct without the heavy model path: only the threshold resolution is
+    # under test, so drive the same arithmetic the constructor uses.
+    # squared-L2 0.05 on unit vectors -> cosine 0.975
+    distance_threshold = 0.05
+    cosine = 1.0 - (distance_threshold / 2.0)
+    assert cosine == pytest.approx(0.975)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/IBM/fms-dgt/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->


## What this PR does / why we need it
Replace the HuggingFace datasets/FAISS-based magpie_distance implementation with a GPU-native matmul exact search plus a lazy FAISS escape hatch for large CPU runs. Key behavioral fixes:

  - Dedup is now order-independent: min_similar_uuid is derived from the lexicographically smallest id in the cluster rather than batch position.
  - Stable ids: missing ids are derived from an md5 content hash instead of a random UUID, so results are reproducible across runs.
  - min_neighbor_distance is now populated from actual similarity scores (converted back to squared-L2) rather than zeroed out.
  - Drops the datasets dependency from the hot path; faiss is imported lazily only when the approximate index is selected.

  New parameters: index_type (auto/flat/hnsw/ivf), max_rows_cpu, max_rows_gpu.

  Also:
  - fix(block): propagate span_writer to child blocks in self._blocks
  - fix(databuilder): warn when a block in the tree still holds a _NoOpSpanWriter after telemetry wiring, indicating unregistered child blocks
  - feat(openai): add reasoning_effort parameter (none/low/medium/high) to OpenAIChatCompletionParameters

## Special notes for your reviewer

## If applicable**
- [ ] this PR contains documentation
- [X] this PR contains unit tests
- [X] this PR has been tested for backwards compatibility
